### PR TITLE
Fix path-info endpoint when no extraData

### DIFF
--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -434,9 +434,7 @@ class Path(Resource):
             validate=validate.OneOf([fee_payer.value for fee_payer in FeePayer]),
             missing="sender",
         ),
-        "extraData": custom_fields.HexEncodedBytes(
-            required=False, missing=hexbytes.HexBytes(b"")
-        ),
+        "extraData": custom_fields.HexEncodedBytes(required=False, missing="0x"),
     }
 
     @use_args(args)


### PR DESCRIPTION
Fix the path-info endpoint. The missing value needs to be the serialized
value and not the deserialized.