### PR TITLE
Add missing arguments on handle_request_parsing_error

### DIFF
--- a/relay/api/app.py
+++ b/relay/api/app.py
@@ -185,7 +185,7 @@ def ApiApp(trustlines):
 
 # This error handler is necessary for usage with Flask-RESTful
 @parser.error_handler
-def handle_request_parsing_error(err, req, schema):
+def handle_request_parsing_error(err, req, schema, status_code, headers):
     """webargs error handler that uses Flask-RESTful's abort function to return
     a JSON error response to the client.
     """

--- a/relay/api/app.py
+++ b/relay/api/app.py
@@ -189,7 +189,11 @@ def handle_request_parsing_error(err, req, schema, status_code, headers):
     """webargs error handler that uses Flask-RESTful's abort function to return
     a JSON error response to the client.
     """
-    abort(422, message="Validation errors in your request", error=err.messages)
+    abort(
+        422,
+        message=f"Validation errors in your request: {err.messages}",
+        error=err.messages,
+    )
 
 
 # Handle all errors as json

--- a/relay/api/fields.py
+++ b/relay/api/fields.py
@@ -87,4 +87,9 @@ class FeePayerField(fields.Field):
     def _deserialize(self, value, attr, data, **kwargs):
 
         # deserialises into the FeePayer enum instance corresponding to the value
-        return FeePayer(value)
+        try:
+            return FeePayer(value)
+        except ValueError:
+            raise ValidationError(
+                f"{attr} has to be one of {[fee_payer.value for fee_payer in FeePayer]}: {value}"
+            )

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -429,11 +429,7 @@ class Path(Resource):
         "maxFees": fields.Int(required=False, missing=None),
         "from": custom_fields.Address(required=True),
         "to": custom_fields.Address(required=True),
-        "feePayer": fields.Str(
-            required=False,
-            validate=validate.OneOf([fee_payer.value for fee_payer in FeePayer]),
-            missing="sender",
-        ),
+        "feePayer": custom_fields.FeePayerField(require=False, missing="sender"),
         "extraData": custom_fields.HexEncodedBytes(required=False, missing="0x"),
     }
 


### PR DESCRIPTION
Add missing arguments on handle_request_parsing_error to properly handle validation errors on the API

Probably missing as a result of the upgrade of marshmallow

Also adds validation on FeePayerField

See: https://github.com/trustlines-protocol/relay/issues/304 for impact / motivation