### PR TITLE
Update changelog to release 0.8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 ==========
 Change Log
 ==========
+`0.8.0`_ (2019-09-02)
+-------------------------------
+* Update marshmallow and other related dependencies
+* Update path finding to ignore frozen trustlines
+* Add information related to frozen trustlines to API
+
+
 `0.7.0`_ (2019-08-08)
 -------------------------------
 * Update web3 to version 5.0.0 and other dependencies
@@ -81,3 +88,4 @@ Change Log
 .. _0.6.0: https://github.com/trustlines-protocol/relay/compare/0.5.0...0.6.0
 .. _0.6.1: https://github.com/trustlines-protocol/relay/compare/0.6.0...0.6.1
 .. _0.7.0: https://github.com/trustlines-protocol/relay/compare/0.6.1...0.7.0
+.. _0.8.0: https://github.com/trustlines-protocol/relay/compare/0.7.0...0.8.0


### PR DESCRIPTION
All tests excepet e2e tests should pass on circle ci. (not merged clientlib yet).