### PR TITLE
Fix internal server error on HexEncodedBytes

### DIFF
--- a/relay/api/app.py
+++ b/relay/api/app.py
@@ -189,10 +189,11 @@ def handle_request_parsing_error(err, req, schema, status_code, headers):
     """webargs error handler that uses Flask-RESTful's abort function to return
     a JSON error response to the client.
     """
+    message = ", ".join(
+        f"{field}: {', '.join(messages)}" for field, messages in err.messages.items()
+    )
     abort(
-        422,
-        message=f"Validation errors in your request: {err.messages}",
-        error=err.messages,
+        422, message=f"Validation errors in your request: {message}", error=err.messages
     )
 
 


### PR DESCRIPTION
Fix the error that the code expected it to be a string. No correctly
checks first if it is a string.
Also improved the error messages.

Closes #304 

Open issue is that the error message for invalid json is inconsistent since the dependency upgrade. 
I opened an issue #319 