### PR TITLE
Add api to get relay version

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -44,6 +44,7 @@ https://relay0.testnet.trustlines.network/api/v1
 - [Relay meta transaction](#relay-meta-transaction)
 - [Deploy identity contract](#deploy-identity-contract)
 - [Get identity information](#get-identity-information)
+- [Get relay version](#get-relay-version)
 
 ---
 
@@ -925,4 +926,23 @@ The endpoint returns an object with the following fields:
 #### Example Response
 ```json
 {"identity": "0x2AbCc1389258Dc187DB787E33FD2B99d53695DE3", "nextNonce": 0, "balance": "0"}
+```
+
+### Get relay version
+#### Request
+```
+GET /version
+```
+
+#### Example Request
+```bash
+curl https://relay0.testnet.trustlines.network/api/v1/version
+```
+
+#### Response
+`string`: relay version
+
+#### Example Response
+```
+relay/v0.7.0
 ```

--- a/relay/api/app.py
+++ b/relay/api/app.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import HTTPException
 from eth_utils import is_address, to_checksum_address, is_checksum_address
 
 from .resources import (
+    Version,
     GraphDump,
     GraphImage,
     RequestEther,
@@ -76,6 +77,7 @@ def ApiApp(trustlines):
     def add_resource(resource, url):
         api.add_resource(resource, url, resource_class_args=[trustlines])
 
+    api.add_resource(Version, "/version")
     add_resource(NetworkList, "/networks")
     add_resource(Network, "/networks/<address:network_address>")
     add_resource(UserList, "/networks/<address:network_address>/users")

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -36,6 +36,8 @@ from relay.logger import get_logger
 
 from relay.network_graph.payment_path import PaymentPath, FeePayer
 
+from relay.utils import get_version
+
 logger = get_logger("api.resources", logging.DEBUG)
 
 
@@ -56,6 +58,11 @@ def dump_result_with_schema(schema):
         return schema.dump(wrapped(*args, **kwargs))
 
     return dump_result
+
+
+class Version(Resource):
+    def get(self):
+        return f"relay/v{get_version()}"
 
 
 class NetworkList(Resource):

--- a/relay/main.py
+++ b/relay/main.py
@@ -8,10 +8,10 @@ import psycogreen.gevent
 psycogreen.gevent.patch_psycopg()  # noqa: E702
 import logging
 
-import pkg_resources
 import click
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
+from relay.utils import get_version
 
 from relay.relay import TrustlinesRelay
 from relay.logger import get_logger
@@ -50,13 +50,6 @@ def patch_warnings_module():
     logger.info(
         "the warnings module has been patched. You will not see the DeprecationWarning messages from web3"
     )
-
-
-def get_version():
-    try:
-        return pkg_resources.get_distribution("trustlines-relay").version
-    except pkg_resources.DistributionNotFound:
-        return "<UNKNOWN>"
 
 
 def _show_version(ctx, param, value):

--- a/relay/utils.py
+++ b/relay/utils.py
@@ -1,5 +1,7 @@
 import web3
 
+import pkg_resources
+
 
 def merge_two_dicts(x, y):
     """Given two dicts, merge them into a new dict as a shallow copy."""
@@ -17,3 +19,10 @@ def trim_args(args):
 
 def sha3(text: str) -> str:
     return web3.Web3.keccak(text=text).hex()
+
+
+def get_version():
+    try:
+        return pkg_resources.get_distribution("trustlines-relay").version
+    except pkg_resources.DistributionNotFound:
+        return "<UNKNOWN>"


### PR DESCRIPTION
Move get_version from main to utils to avoid circular dependencies
Flake8 would complain if I put the def of get_version before the local imports to avoid circular dependencies and I felt like it did not belong elsewhere

closes https://github.com/trustlines-protocol/relay/issues/317