### PR TITLE
Do not keep the session object alive

### DIFF
--- a/relay/pushservice/client_token_db.py
+++ b/relay/pushservice/client_token_db.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, String
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.exc import IntegrityError
+from contextlib import contextmanager
 
 Base = declarative_base()
 
@@ -28,23 +29,39 @@ TokenMapping = namedtuple("TokenMapping", ["user_address", "client_token"])
 
 class ClientTokenDB:
     def __init__(self, engine) -> None:
-        Session = sessionmaker(bind=engine)
+        self._make_session = sessionmaker(bind=engine)
         Base.metadata.create_all(engine)
-        self.session = Session()
+
+    @contextmanager
+    def session(self):
+        """Provide a transactional scope around a series of operations."""
+        session = self._make_session()
+        try:
+            yield session
+            session.commit()
+        except BaseException:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
     def get_client_tokens(self, user_address: str) -> Iterable[str]:
-        return [
-            client_token
-            for (client_token,) in self.session.query(TokenMappingORM.client_token)
-            .filter(TokenMappingORM.user_address == user_address)
-            .all()
-        ]
+        with self.session() as session:
+            return [
+                client_token
+                for (client_token,) in session.query(TokenMappingORM.client_token)
+                .filter(TokenMappingORM.user_address == user_address)
+                .all()
+            ]
 
     def get_all_client_tokens(self) -> Iterable[TokenMapping]:
-        return [
-            TokenMapping(token_mapping_orm.user_address, token_mapping_orm.client_token)
-            for token_mapping_orm in (self.session.query(TokenMappingORM).all())
-        ]
+        with self.session() as session:
+            return [
+                TokenMapping(
+                    token_mapping_orm.user_address, token_mapping_orm.client_token
+                )
+                for token_mapping_orm in (session.query(TokenMappingORM).all())
+            ]
 
     def add_client_token(self, user_address: str, client_token: str) -> None:
         """
@@ -55,20 +72,20 @@ class ClientTokenDB:
         Raises:
         ClientTokenAlreadyExistsException: If the combination of user_address and client_token already exists
         """
-        tokenMappingOrm = TokenMappingORM(
-            user_address=user_address, client_token=client_token
-        )
-        try:
-            self.session.add(tokenMappingOrm)
-            self.session.commit()
-        except IntegrityError as e:
-            self.session.rollback()
-            raise ClientTokenAlreadyExistsException from e
+        with self.session() as session:
+            tokenMappingOrm = TokenMappingORM(
+                user_address=user_address, client_token=client_token
+            )
+            try:
+                session.add(tokenMappingOrm)
+                session.commit()
+            except IntegrityError as e:
+                raise ClientTokenAlreadyExistsException from e
 
     def delete_client_token(self, user_address: str, client_token: str) -> None:
         """Deletes a client token from the given user address"""
-        self.session.query(TokenMappingORM).filter(
-            TokenMappingORM.user_address == user_address,
-            TokenMappingORM.client_token == client_token,
-        ).delete()
-        self.session.commit()
+        with self.session() as session:
+            session.query(TokenMappingORM).filter(
+                TokenMappingORM.user_address == user_address,
+                TokenMappingORM.client_token == client_token,
+            ).delete()


### PR DESCRIPTION
The ClientTokenDB class could not be used from multiple greenlets
previously. It resulted in the following errors being thrown:

,----
| <class 'sqlalchemy.exc.ProgrammingError'> (psycopg2.ProgrammingError)
| execute cannot be used while an asynchronous query is underway
`----

We now create a sesssion object for each method and make sure it's
lifetime is being handled correctly with a contextmanager.

Also we have seen the following errors on the development server,
see https://github.com/trustlines-network/deployment-config/issues/40:

,----
| sqlalchemy.exc.InvalidRequestError: This Session's transaction has
| been rolled back due to a previous exception during flush. To begin a
| new transaction with this Session, first issue
| Session.rollback(). Original exception
| was: (psycopg2.OperationalError) SSL connection has been closed
| unexpectedly
`----

These should also be fixed now.