### PR TITLE
Update endpoint to deploy identity to deploy a proxy

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -110,8 +110,8 @@ toml==0.10.0
 toolz==0.10.0
 tox==3.13.2
 trie==1.4.0
-trustlines-contracts-bin==0.9.0
-trustlines-contracts-deploy==0.9.0
+trustlines-contracts-bin==0.9.1
+trustlines-contracts-deploy==0.9.1
 typed-ast==1.4.0
 typing-extensions==3.7.4
 urllib3==1.25.3

--- a/constraints.txt
+++ b/constraints.txt
@@ -13,7 +13,7 @@ certifi==2019.6.16
 cfgv==2.0.1
 chardet==3.0.4
 Click==7.0
-contract-deploy-tools==0.5.1
+contract-deploy-tools==0.6.0
 coverage==4.5.4
 cytoolz==0.10.0
 decorator==4.4.0
@@ -110,8 +110,8 @@ toml==0.10.0
 toolz==0.10.0
 tox==3.13.2
 trie==1.4.0
-trustlines-contracts-bin==0.9.1
-trustlines-contracts-deploy==0.9.1
+trustlines-contracts-bin==0.9.2
+trustlines-contracts-deploy==0.9.2
 typed-ast==1.4.0
 typing-extensions==3.7.4
 urllib3==1.25.3

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -16,7 +16,10 @@ from relay.blockchain.delegate import InvalidIdentityContractException
 from relay.utils import sha3
 from relay.blockchain.currency_network_proxy import CurrencyNetworkProxy
 from relay.blockchain.unw_eth_proxy import UnwEthProxy
-from relay.blockchain.delegate import InvalidMetaTransactionException
+from relay.blockchain.delegate import (
+    InvalidMetaTransactionException,
+    IdentityDeploymentFailedException,
+)
 from relay.api import fields as custom_fields
 from .schemas import (
     CurrencyNetworkEventSchema,
@@ -392,9 +395,12 @@ class DeployIdentity(Resource):
         implementation_address = args["implementationAddress"]
         factory_address = args["factoryAddress"]
         signature = args["signature"]
-        identity_contract_address = self.trustlines.deploy_identity(
-            factory_address, implementation_address, signature
-        )
+        try:
+            identity_contract_address = self.trustlines.deploy_identity(
+                factory_address, implementation_address, signature
+            )
+        except IdentityDeploymentFailedException:
+            abort(400, "The identity deployment failed, identity already deployed?")
         return self.trustlines.get_identity_info(identity_contract_address)
 
 

--- a/relay/api/resources.py
+++ b/relay/api/resources.py
@@ -380,13 +380,21 @@ class DeployIdentity(Resource):
     def __init__(self, trustlines: TrustlinesRelay) -> None:
         self.trustlines = trustlines
 
-    args = {"ownerAddress": custom_fields.Address(required=True)}
+    args = {
+        "factoryAddress": custom_fields.Address(required=True),
+        "implementationAddress": custom_fields.Address(required=True),
+        "signature": custom_fields.HexEncodedBytes(required=True),
+    }
 
     @use_args(args)
     @dump_result_with_schema(IdentityInfosSchema())
     def post(self, args):
-        owner_address = args["ownerAddress"]
-        identity_contract_address = self.trustlines.deploy_identity(owner_address)
+        implementation_address = args["implementationAddress"]
+        factory_address = args["factoryAddress"]
+        signature = args["signature"]
+        identity_contract_address = self.trustlines.deploy_identity(
+            factory_address, implementation_address, signature
+        )
         return self.trustlines.get_identity_info(identity_contract_address)
 
 

--- a/relay/blockchain/delegate.py
+++ b/relay/blockchain/delegate.py
@@ -3,10 +3,8 @@ from tldeploy.identity import (
     Delegate as DelegateImplementation,
     UnexpectedIdentityContractException,
 )
-from tldeploy.core import deploy_proxied_identity
-from deploy_tools.deploy import (
-    TransactionFailed,
-)  # I think this is wrong, the error should be importable form tldeply.core because raised by deploy_proxied_identity
+from tldeploy.identity import deploy_proxied_identity
+from deploy_tools.deploy import TransactionFailed
 
 
 class Delegate:
@@ -31,9 +29,12 @@ class Delegate:
 
     def deploy_identity(self, factory_address, implementation_address, signature):
         try:
-            return deploy_proxied_identity(
-                self._web3, factory_address, implementation_address, signature
-            ).address
+            # when getting an address via contract.address, the address might not be a checksummed address
+            return self._web3.toChecksumAddress(
+                deploy_proxied_identity(
+                    self._web3, factory_address, implementation_address, signature
+                ).address
+            )
         except TransactionFailed:
             raise IdentityDeploymentFailedException
 

--- a/relay/blockchain/delegate.py
+++ b/relay/blockchain/delegate.py
@@ -4,6 +4,9 @@ from tldeploy.identity import (
     UnexpectedIdentityContractException,
 )
 from tldeploy.core import deploy_proxied_identity
+from deploy_tools.deploy import (
+    TransactionFailed,
+)  # I think this is wrong, the error should be importable form tldeply.core because raised by deploy_proxied_identity
 
 
 class Delegate:
@@ -27,9 +30,12 @@ class Delegate:
             raise InvalidMetaTransactionException
 
     def deploy_identity(self, factory_address, implementation_address, signature):
-        return deploy_proxied_identity(
-            self._web3, factory_address, implementation_address, signature
-        ).address
+        try:
+            return deploy_proxied_identity(
+                self._web3, factory_address, implementation_address, signature
+            ).address
+        except TransactionFailed:
+            raise IdentityDeploymentFailedException
 
     def calc_next_nonce(self, identity_address: str):
         try:
@@ -43,4 +49,8 @@ class InvalidIdentityContractException(Exception):
 
 
 class InvalidMetaTransactionException(Exception):
+    pass
+
+
+class IdentityDeploymentFailedException(Exception):
     pass

--- a/relay/blockchain/delegate.py
+++ b/relay/blockchain/delegate.py
@@ -3,7 +3,7 @@ from tldeploy.identity import (
     Delegate as DelegateImplementation,
     UnexpectedIdentityContractException,
 )
-from tldeploy.core import deploy_identity
+from tldeploy.core import deploy_proxied_identity
 
 
 class Delegate:
@@ -26,8 +26,10 @@ class Delegate:
         else:
             raise InvalidMetaTransactionException
 
-    def deploy_identity(self, owner_address: str) -> str:
-        return deploy_identity(self._web3, owner_address).address
+    def deploy_identity(self, factory_address, implementation_address, signature):
+        return deploy_proxied_identity(
+            self._web3, factory_address, implementation_address, signature
+        ).address
 
     def calc_next_nonce(self, identity_address: str):
         try:

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -187,8 +187,10 @@ class TrustlinesRelay:
     def get_users_of_network(self, network_address: str):
         return self.currency_network_graphs[network_address].users
 
-    def deploy_identity(self, owner_address):
-        return self.delegate.deploy_identity(owner_address)
+    def deploy_identity(self, factory_address, implementation_address, signature):
+        return self.delegate.deploy_identity(
+            factory_address, implementation_address, signature
+        )
 
     def delegate_metatransaction(self, meta_transaction: MetaTransaction):
         return self.delegate.send_signed_meta_transaction(meta_transaction)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ gevent
 web3>=4.7.1
 networkx>=2.0
 pygraphviz
-trustlines-contracts-bin>=0.9.1
-trustlines-contracts-deploy>=0.9.1
+trustlines-contracts-bin>=0.9.2
+trustlines-contracts-deploy>=0.9.2
 sqlalchemy
 eth-utils
 tinyrpc

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ gevent
 web3>=4.7.1
 networkx>=2.0
 pygraphviz
-trustlines-contracts-bin>=0.9.0
-trustlines-contracts-deploy>=0.9.0
+trustlines-contracts-bin>=0.9.1
+trustlines-contracts-deploy>=0.9.1
 sqlalchemy
 eth-utils
 tinyrpc


### PR DESCRIPTION
Requires the method to deploy a proxied identity in trustlines-contracts-deploy

Does not contain any protection mechanism as to whether the factory/implementation is know to the relay or about the owner.

If the identity is already deployed, the deployment transaction will fail, I try to handle this error but I am not sure that the way I import the error is correct, see: https://github.com/trustlines-protocol/relay/pull/329/files#diff-2b61c07331ed4c639eeadbb73e2dcf8eR9

closes https://github.com/trustlines-protocol/relay/issues/325