### PR TITLE
Update contract-deploy-tools version to 0.6.1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -13,7 +13,7 @@ certifi==2019.6.16
 cfgv==2.0.1
 chardet==3.0.4
 Click==7.0
-contract-deploy-tools==0.6.0
+contract-deploy-tools==0.6.1
 coverage==4.5.4
 cytoolz==0.10.0
 decorator==4.4.0


### PR DESCRIPTION
Related to: trustlines-network/project#703