### PR TITLE
Option to restrict identity deployment to known factories

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -43,6 +43,7 @@ https://relay0.testnet.trustlines.network/api/v1
 - [Relay transaction](#relay-transaction)
 - [Relay meta transaction](#relay-meta-transaction)
 - [Deploy identity contract](#deploy-identity-contract)
+- [Get authorized identity factories](#get-authorized-identity-factories)
 - [Get identity information](#get-identity-information)
 - [Get relay version](#get-relay-version)
 
@@ -897,6 +898,25 @@ The endpoint returns an object with the following fields:
 #### Example Response
 ```json
 {"identity": "0x43950642C8685ED8e3Fb89a5C5aeCb12862A87fd", "nextNonce": 0, "balance": "0"}
+```
+
+### Get authorized identity factories
+#### Request
+```
+GET /factories
+```
+
+#### Example Request
+```bash
+curl https://relay0.testnet.trustlines.network/api/v1/factories
+```
+
+#### Response
+`string[]`: list of known identity factories through which identity deployment is possible
+
+#### Example Response
+```
+["0x43950642C8685ED8e3Fb89a5C5aeCb12862A87fd"]
 ```
 
 ### Get identity information

--- a/relay/api/app.py
+++ b/relay/api/app.py
@@ -27,6 +27,7 @@ from .resources import (
     ContactList,
     DeployIdentity,
     EventsNetwork,
+    Factories,
     GraphDump,
     GraphImage,
     IdentityInfos,
@@ -123,6 +124,7 @@ def ApiApp(trustlines):
         add_resource(DeployIdentity, "/identities")
 
     add_resource(IdentityInfos, "/identities/<address:identity_address>")
+    add_resource(Factories, "/factories")
     add_resource(OrderBook, "/exchange/orderbook")
     add_resource(Orders, "/exchange/orders")
     add_resource(OrderSubmission, "/exchange/order")

--- a/relay/blockchain/delegate.py
+++ b/relay/blockchain/delegate.py
@@ -8,13 +8,13 @@ from tldeploy.identity import (
 
 
 class Delegate:
-    def __init__(self, web3, node_address, identity_contract_abi):
-
+    def __init__(self, web3, node_address, identity_contract_abi, known_factories):
         self._web3 = web3
 
         self.delegate = DelegateImplementation(
             node_address, web3=web3, identity_contract_abi=identity_contract_abi
         )
+        self.known_factories = known_factories
 
     def send_signed_meta_transaction(self, signed_meta_transaction: MetaTransaction):
         try:
@@ -28,6 +28,8 @@ class Delegate:
             raise InvalidMetaTransactionException
 
     def deploy_identity(self, factory_address, implementation_address, signature):
+        if factory_address not in self.known_factories:
+            raise UnknownIdentityFactoryException(factory_address)
         try:
             # when getting an address via contract.address, the address might not be a checksummed address
             return self._web3.toChecksumAddress(
@@ -54,4 +56,8 @@ class InvalidMetaTransactionException(Exception):
 
 
 class IdentityDeploymentFailedException(Exception):
+    pass
+
+
+class UnknownIdentityFactoryException(Exception):
     pass

--- a/tests/chain_integration/test_delegate.py
+++ b/tests/chain_integration/test_delegate.py
@@ -24,9 +24,11 @@ def delegate_address(web3):
 
 
 @pytest.fixture(scope="session")
-def delegate(web3, delegate_address, contracts):
+def delegate(web3, delegate_address, contracts, proxy_factory):
     identity_contract_abi = contracts["Identity"]["abi"]
-    return Delegate(web3, delegate_address, identity_contract_abi)
+    return Delegate(
+        web3, delegate_address, identity_contract_abi, [proxy_factory.address]
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Give the option to restrict identity deployment to known factories va config

if no config is given, it is unrestricted

WIP: add an endpoint to ask for known identity proxies.

closes: https://github.com/trustlines-protocol/relay/issues/333

Tested via: https://github.com/trustlines-protocol/end2end/compare/test-restricted-factories?expand=1
I am not sure how to make this test clean / whether the test is needed.