### PR TITLE
Remove duplicate logging message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Change Log
 - Remove gas estimation on find path requests (BREAKING)
 - Change: deploy identity requests are only allowed for known identity factories (BREAKING)
 - Change config file format to TOML
-- Fix an issue that identity deployment did not work when two identity were deployed in the same block. 
+- Fix an issue that identity deployment did not work when two identity were deployed in the same block.
 
 `0.9.0`_ (2019-10-05)
 -------------------------------

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -273,7 +273,6 @@ class TrustlinesRelay:
             )
 
     def new_known_factory(self, address: str) -> None:
-        logger.info("New identity factory contract: {}".format(address))
         assert is_checksum_address(address)
         if address not in self.known_identity_factories:
             logger.info("New identity factory contract: {}".format(address))


### PR DESCRIPTION
Remove duplicate logging message from new identity factory that was logged even when no new factory was found.