### PR TITLE
Change default currency network of fees for delegation to empty

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,7 @@ gasPrice = 0
 
 [relay.delegationFees]
 value = [0]
-currencyNetwork = ["0x"]
+currencyNetwork = [""]
 
 # Configure logging
 [logging.root]

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -229,7 +229,7 @@ class TrustlinesRelay:
             self.contracts["Identity"]["abi"],
             self.known_identity_factories,
             self.config.get("delegationFees", {}).get("value", [0]),
-            self.config.get("delegationFees", {}).get("currencyNetwork", ["0x"]),
+            self.config.get("delegationFees", {}).get("currencyNetwork", [""]),
         )
         self._start_listen_on_new_addresses()
 


### PR DESCRIPTION
The clientlib will ask for the currency network of fees and
use it for its meta transaction so it should pass the schema
validation which expect an address / missing