### PR TITLE
Fix from tests imports

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,9 +15,9 @@ ssl = false
 method = "rpc"
 gasPrice = 0
 
-[relay.delegationFees]
-value = [0]
-currencyNetwork = [""]
+[[relay.delegationFees]]
+# value = 0
+# currencyNetwork = "0x000..."
 
 # Configure logging
 [logging.root]

--- a/relay/blockchain/delegate.py
+++ b/relay/blockchain/delegate.py
@@ -18,8 +18,7 @@ class Delegate:
         node_address,
         identity_contract_abi,
         known_factories,
-        delegation_fees_values,
-        currency_networks_of_fees,
+        delegation_fees,
     ):
         self._web3 = web3
 
@@ -27,12 +26,7 @@ class Delegate:
             node_address, web3=web3, identity_contract_abi=identity_contract_abi
         )
         self.known_factories = known_factories
-        self.delegation_fees = [
-            DelegationFees(delegation_fees_value, currency_network_of_fees)
-            for (delegation_fees_value, currency_network_of_fees) in zip(
-                delegation_fees_values, currency_networks_of_fees
-            )
-        ]
+        self.delegation_fees = delegation_fees
 
     def send_signed_meta_transaction(self, signed_meta_transaction: MetaTransaction):
         try:

--- a/relay/relay.py
+++ b/relay/relay.py
@@ -35,7 +35,7 @@ from .blockchain import (
     unw_eth_events,
 )
 from .blockchain.currency_network_proxy import CurrencyNetworkProxy
-from .blockchain.delegate import Delegate
+from .blockchain.delegate import Delegate, DelegationFees
 from .blockchain.events import BlockchainEvent
 from .blockchain.exchange_proxy import ExchangeProxy
 from .blockchain.node import Node
@@ -223,13 +223,19 @@ class TrustlinesRelay:
         logger.info("using web3 URL {}".format(url))
         self._web3 = Web3(Web3.HTTPProvider(url))
         self.node = Node(self._web3, fixed_gas_price=self.fixed_gas_price)
+
+        delegation_fees = [
+            DelegationFees(value=d["value"], currency_network=d["currencyNetwork"])
+            for d in self.config.get("delegationFees", [])
+            if d
+        ]
+
         self.delegate = Delegate(
             self._web3,
             self.node.address,
             self.contracts["Identity"]["abi"],
             self.known_identity_factories,
-            self.config.get("delegationFees", {}).get("value", [0]),
-            self.config.get("delegationFees", {}).get("currencyNetwork", [""]),
+            delegation_fees=delegation_fees,
         )
         self._start_listen_on_new_addresses()
 

--- a/tests/chain_integration/test_delegate.py
+++ b/tests/chain_integration/test_delegate.py
@@ -13,6 +13,7 @@ from web3 import Web3
 
 from relay.blockchain.delegate import (
     Delegate,
+    DelegationFees,
     InvalidIdentityContractException,
     InvalidMetaTransactionException,
 )
@@ -26,14 +27,14 @@ def delegate_address(web3):
 @pytest.fixture(scope="session")
 def delegate(web3, delegate_address, contracts, proxy_factory, currency_network):
     identity_contract_abi = contracts["Identity"]["abi"]
-    delegation_fees_value = 1
     return Delegate(
         web3,
         delegate_address,
         identity_contract_abi,
         [proxy_factory.address],
-        [delegation_fees_value],
-        [currency_network.address],
+        delegation_fees=[
+            DelegationFees(value=1, currency_network=currency_network.address)
+        ],
     )
 
 

--- a/tests/unit/network_graph/test_graph.py
+++ b/tests/unit/network_graph/test_graph.py
@@ -1,7 +1,7 @@
 import time
 
 import pytest
-from tests.unit.network_graph.conftest import addresses
+from conftest import addresses
 
 from relay.blockchain.currency_network_proxy import Trustline
 from relay.network_graph.graph import (

--- a/tests/unit/network_graph/test_interests.py
+++ b/tests/unit/network_graph/test_interests.py
@@ -1,7 +1,7 @@
 import math
 
 import pytest
-from tests.unit.network_graph.conftest import addresses
+from conftest import addresses
 
 from relay.blockchain.currency_network_proxy import Trustline
 from relay.network_graph.graph import Account, NetworkGraphConfig


### PR DESCRIPTION
(This is based on PR #358, please only review the last commit)

Fix 'from tests' imports
    
We do not have tests/__init__.py here. Python makes our tests
directory an implicit namespace package iff there is no explicit tests
package on the PYTHONPATH. These 'from tests' imports will not work in
the latter case.
