### PR TITLE
Remove unused ERC20 functions on currency networks

### DIFF
--- a/relay/blockchain/currency_network_proxy.py
+++ b/relay/blockchain/currency_network_proxy.py
@@ -78,12 +78,6 @@ class CurrencyNetworkProxy(Proxy):
     def account(self, a_address: str, b_address: str):
         return self._proxy.functions.getAccount(a_address, b_address).call()
 
-    def spendable(self, a_address: str):
-        return self._proxy.functions.spendable(a_address).call()
-
-    def spendableTo(self, a_address: str, b_address: str):
-        return self._proxy.functions.spendableTo(a_address, b_address).call()
-
     def gen_graph_representation(self) -> List[Trustline]:
         """Returns the trustlines network as a dict address -> list of Friendships"""
         result = []

--- a/tests/chain_integration/test_currency_network.py
+++ b/tests/chain_integration/test_currency_network.py
@@ -73,14 +73,6 @@ def test_users(currency_network_with_trustlines, accounts):
     assert currency_network_with_trustlines.users == accounts[0:5]
 
 
-def test_spendable(currency_network_with_trustlines, accounts):
-    assert currency_network_with_trustlines.spendable(accounts[1]) == 350
-
-
-def test_spendable_to(currency_network_with_trustlines, accounts):
-    assert currency_network_with_trustlines.spendableTo(accounts[3], accounts[4]) == 450
-
-
 def test_gen_graph_representation(currency_network_with_trustlines, accounts):
     graph_representation = currency_network_with_trustlines.gen_graph_representation()
 


### PR DESCRIPTION
Closes: #362

@berndbohmeier @cducrest the output of the failing end-to-end tests look similar to the ones at `master`. I guess that it is broken at the moment and they are "supposed" to fail?