### PR TITLE
Make the relay server sign transactions

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -13,7 +13,7 @@ certifi==2019.6.16
 cfgv==2.0.1
 chardet==3.0.4
 Click==7.0
-contract-deploy-tools==0.6.1
+contract-deploy-tools==0.7.1
 coverage==4.5.4
 cytoolz==0.10.0
 decorator==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,6 @@ flake8-string-format
 pytest
 pytest-cov
 mypy
-contract-deploy-tools>=0.2.1
+contract-deploy-tools>=0.7.1
 tox
 pre-commit

--- a/src/relay/signing_middleware.py
+++ b/src/relay/signing_middleware.py
@@ -66,6 +66,8 @@ def make_prepare_signing_middleware(default_from_address):
 
 
 def install_signing_middleware(w3, account):
+    if w3.eth.defaultAccount:
+        raise RuntimeError("default account already set")
     w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
     w3.eth.defaultAccount = account.address
     w3.middleware_onion.add(make_prepare_signing_middleware(account.address))

--- a/src/relay/signing_middleware.py
+++ b/src/relay/signing_middleware.py
@@ -1,0 +1,34 @@
+"""Provide a signing middleware that automatically signs transactions
+
+
+"""
+import copy
+
+from web3.middleware import construct_sign_and_send_raw_middleware
+
+
+def make_set_from_address_middleware(default_from_address):
+    """
+    The web3.middleware.signing middleware needs the from field to be set, which we do here.
+    """
+
+    def set_from_middleware(make_request, w3):
+        def middleware(method, params):
+            if method != "eth_sendTransaction":
+                return make_request(method, params)
+            if "from" in params[0]:
+                return make_request(method, params)
+
+            params = copy.deepcopy(params)
+            params["from"] = default_from_address
+            return make_request(method, params)
+
+        return middleware
+
+    return set_from_middleware
+
+
+def install_signing_middleware(w3, account):
+    w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
+    w3.eth.defaultAccount = account.address
+    w3.middleware_onion.add(make_set_from_address_middleware(account.address))

--- a/src/relay/signing_middleware.py
+++ b/src/relay/signing_middleware.py
@@ -1,34 +1,71 @@
 """Provide a signing middleware that automatically signs transactions
 
+We save us from keeping track of nonces by asking parity for the next
+nonce and serializing 'eth_sendTransaction' requests. The actual
+signing is done by the web3 signing middleware.
 
+This module kinds of replaces running parity with an unlocked account
 """
-import copy
 
+import copy
+import logging
+
+import eth_utils
 from web3.middleware import construct_sign_and_send_raw_middleware
 
+from relay.concurrency_utils import synchronized
 
-def make_set_from_address_middleware(default_from_address):
+logger = logging.getLogger(__name__)
+
+
+@synchronized
+def _eth_send_transaction(make_request, w3, method, params):
+    """Run a eth_sendTransaction request
+
+determines next nonce to be used for the eth_sendTransaction
+request, sets that nonce and executes the request. The @synchronized
+decorator will make sure only one _eth_send_transaction runs at the same time.
+
+This uses the parity_nextNonce function, hence it only works with
+parity.
+"""
+    assert method == "eth_sendTransaction"
+    if "nonce" not in params[0]:
+        params[0]["nonce"] = int(
+            w3.manager.request_blocking("parity_nextNonce", [params[0]["from"]]), 16
+        )
+    nonce = params[0]["nonce"]
+    logger.debug("_eth_send_transaction start: nonce=%s %s", nonce, params)
+
+    res = make_request(method, params)
+    logger.debug("_eth_send_transaction return: nonce=%s %s", nonce, res)
+    return res
+
+
+def make_prepare_signing_middleware(default_from_address):
     """
     The web3.middleware.signing middleware needs the from field to be set, which we do here.
     """
 
-    def set_from_middleware(make_request, w3):
+    def prepare_signing_middleware(make_request, w3):
         def middleware(method, params):
             if method != "eth_sendTransaction":
                 return make_request(method, params)
-            if "from" in params[0]:
+            from_address = params[0].get("from")
+            if from_address is not None and not eth_utils.is_same_address(
+                from_address, default_from_address
+            ):
                 return make_request(method, params)
-
             params = copy.deepcopy(params)
-            params["from"] = default_from_address
-            return make_request(method, params)
+            params[0]["from"] = default_from_address
+            return _eth_send_transaction(make_request, w3, method, params)
 
         return middleware
 
-    return set_from_middleware
+    return prepare_signing_middleware
 
 
 def install_signing_middleware(w3, account):
     w3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
     w3.eth.defaultAccount = account.address
-    w3.middleware_onion.add(make_set_from_address_middleware(account.address))
+    w3.middleware_onion.add(make_prepare_signing_middleware(account.address))

--- a/tests/unit/test_signing_middleware.py
+++ b/tests/unit/test_signing_middleware.py
@@ -1,0 +1,103 @@
+import attr
+import eth_account
+import eth_tester
+import pytest
+from web3 import Web3
+from web3.providers.eth_tester import EthereumTesterProvider
+
+from relay import signing_middleware
+
+
+def parity_next_nonce(make_request, w3):
+    """middleware that implements parity_nextNonce
+
+We need this, since we're talking to the eth_tester chain
+"""
+
+    def middleware(method, params):
+        if method != "parity_nextNonce":
+            return make_request(method, params)
+        res = make_request("eth_getTransactionCount", [params[0], "pending"])
+        res["result"] = hex(res["result"])
+        return res
+
+    return middleware
+
+
+@pytest.fixture
+def signing_account():
+    """account used for signing"""
+    return eth_account.Account.create()
+
+
+@pytest.fixture()
+def w3(signing_account):
+    """
+    Web3 object connected to the ethereum tester chain
+    """
+    chain = eth_tester.EthereumTester(eth_tester.PyEVMBackend())
+    chain.send_transaction(
+        {
+            "from": chain.get_accounts()[0],
+            "to": signing_account.address,
+            "gas": 21000,
+            "value": 10_000_000,
+        }
+    )
+    w3 = Web3(EthereumTesterProvider(chain))
+    w3.middleware_onion.add(parity_next_nonce)
+    signing_middleware.install_signing_middleware(w3, signing_account)
+    return w3
+
+
+def test_eth_default_account(w3, signing_account):
+    assert w3.eth.defaultAccount == signing_account.address
+    with pytest.raises(RuntimeError):
+        signing_middleware.install_signing_middleware(w3, signing_account)
+
+
+@attr.s
+class SendTxParams:
+    set_from = attr.ib()
+    set_nonce = attr.ib()
+
+
+example_send_tx_params = [
+    SendTxParams(set_nonce=False, set_from=False),
+    SendTxParams(set_nonce=False, set_from=False),
+    SendTxParams(set_nonce=True, set_from=False),
+    SendTxParams(set_nonce=True, set_from=False),
+    SendTxParams(set_nonce=True, set_from=True),
+    SendTxParams(set_nonce=True, set_from=True),
+    SendTxParams(set_nonce=False, set_from=True),
+    SendTxParams(set_nonce=False, set_from=True),
+]
+
+
+def test_auto_signing(w3, signing_account):
+    signing_account_balance_before = w3.eth.getBalance(
+        signing_account.address, block_identifier="latest"
+    )
+    receiver = eth_account.Account.create().address
+
+    value = 1
+    sum_send = 0
+    nonce = 0
+    for params, value in zip(example_send_tx_params, range(1, 100)):
+        d = {"value": value, "to": receiver}
+        if params.set_nonce:
+            d["nonce"] = nonce
+        if params.set_from:
+            d["from"] = signing_account.address
+        print("send-tx:", d)
+        tx_hash = w3.eth.sendTransaction(d)
+        receipt = w3.eth.waitForTransactionReceipt(tx_hash)
+        assert receipt.status == 1
+        sum_send += value
+        receiver_balance = w3.eth.getBalance(receiver, block_identifier="latest")
+        assert receiver_balance == sum_send
+        signing_account_balance = w3.eth.getBalance(
+            signing_account.address, block_identifier="latest"
+        )
+        assert signing_account_balance < signing_account_balance_before - sum_send
+        nonce += 1


### PR DESCRIPTION
To make the relay server sign transactions locally, you must configure
the account the be used via a snippet like the following in the TOML
configuration file:

,----
| [relay.account]
| keystore_path = "path/to/keystore.json"
| keystore_password_path = "path/to/passwd.txt"
`----

We use middleware that automatically signs transactions.

This requires the latest contract-deploy-tools.

This is an experimental feature. There might be race conditions with
the nonce handling, because previously we relied on parity to handle
the nonce.