### PR TITLE
Report errors to sentry

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,6 +19,11 @@ gasPrice = 0
 # value = 0
 # currencyNetwork = "0x000..."
 
+# Configure a sentry DSN to report errors to sentry
+# [relay.sentry]
+# dsn = "https://f3e...@sentry.io/..."
+
+
 # Configure logging
 [logging.root]
 level = "INFO"

--- a/constraints.txt
+++ b/constraints.txt
@@ -6,6 +6,7 @@ attrdict==2.0.1
 attrs==19.1.0
 base58==1.0.3
 black==19.3b0
+blinker==1.4
 CacheControl==0.12.5
 cached-property==1.5.1
 cachetools==2.1.0
@@ -73,7 +74,6 @@ packaging==19.1
 parsimonious==0.8.1
 pendulum==2.0.5
 pip==19.2.1
-pkg-resources==0.0.0
 pluggy==0.12.0
 pre-commit==1.18.0
 protobuf==3.9.0
@@ -101,6 +101,7 @@ requests==2.22.0
 rlp==1.1.0
 rsa==3.4.2
 semantic-version==2.6.0
+sentry-sdk==0.14.1
 setuptools==41.0.1
 six==1.12.0
 SQLAlchemy==1.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flask
 flask_restful
 flask_cors
+sentry-sdk[flask]
 webargs
 gevent
 web3>=4.7.1

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "flask",
         "flask_restful",
         "flask_cors",
+        "sentry-sdk[flask]",
         "webargs",
         "gevent",
         "web3>=4.7.1",

--- a/src/relay/main.py
+++ b/src/relay/main.py
@@ -3,6 +3,7 @@ import logging
 import logging.config
 
 import click
+import sentry_sdk.integrations.flask
 import toml
 from gevent.pywsgi import WSGIServer
 from geventwebsocket.handler import WebSocketHandler
@@ -113,6 +114,12 @@ def main(ctx, port, config, addresses, version):
         else:
             config_dict = toml.load(config_file)
     configure_logging(config_dict)
+    sentry_dsn = config_dict["relay"].get("sentry", {}).get("dsn")
+    if sentry_dsn:
+        sentry_sdk.init(
+            dsn=sentry_dsn,
+            integrations=[sentry_sdk.integrations.flask.FlaskIntegration()],
+        )
 
     trustlines = TrustlinesRelay(
         config=config_dict["relay"], addresses_json_path=addresses


### PR DESCRIPTION
This uses sentry's flask integration for reporting errors to
sentry. THis is a good first start, though we may need more reporting
in case an error doesn't happen during handling of a HTTP request or
we manually return an error code.

See https://github.com/trustlines-protocol/relay/issues/92