### PR TITLE
Pushnotifications do not mark messages as read

### DIFF
--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -406,7 +406,8 @@ class TrustlinesRelay:
         )
         client = PushNotificationClient(self._firebase_raw_push_service, client_token)
         self.subjects[user_address].subscribe(client)
-        self.messaging[user_address].subscribe(client)
+        # Silent: Do not mark notifications as read, so that we can query them later
+        self.messaging[user_address].subscribe(client, silent=True)
 
     def _stop_pushnotifications(self, user_address: str, client_token: str) -> None:
         success = False

--- a/tests/unit/test_streams.py
+++ b/tests/unit/test_streams.py
@@ -175,3 +175,17 @@ def test_close_client(subject):
     assert len(client.subscriptions) == 0
     assert subscription1.closed
     assert subscription2.closed
+
+
+def test_not_reading_client_does_not_mark_as_read(messaging_subject, client):
+    # A silent client should not mark messages as read
+    messaging_subject.subscribe(client, silent=True)
+    assert messaging_subject.publish(event=MessageEvent("test2", timestamp=0)) == 0
+    missed_messages = messaging_subject.get_missed_messages()
+    assert len(missed_messages) == 1
+
+    # A normal client should mark messages as read
+    messaging_subject.subscribe(client, silent=False)
+    assert messaging_subject.publish(event=MessageEvent("test2", timestamp=0)) == 1
+    missed_messages = messaging_subject.get_missed_messages()
+    assert len(missed_messages) == 0


### PR DESCRIPTION
Quickfix for the problem that messages are not delivered.
Because we do not send message content anymore over pushnotifications,
pushnotifications should not mark messages as read, so that we can still
read the message later via websockets.