### PR TITLE
Meta tx status endpoint

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -1089,6 +1089,33 @@ curl --header "Content-Type: application/json" \
 
 ---
 
+### Status of meta transaction
+Get the status of a meta transaction for an identity.
+
+#### Request
+```
+GET /identities/:identityAddress/meta-transactions/:metaTransactionHash/status
+```
+
+#### Example Request
+```bash
+curl https://relay0.testnet.trustlines.network/api/v1/identities/0xF2E246BB76DF876Cef8b38ae84130F4F55De395b/meta-transactions/0x51a240271AB8AB9f9a21C82d9a85396b704E164d/status
+```
+
+#### Response
+| Attribute             | Type   | Description                                                       |
+|-----------------------|--------|-------------------------------------------------------------------|
+| status                | string | one of success, failure, pending, or not found                    |
+
+#### Example Response
+```json
+{
+  "status": "success"
+}
+```
+
+---
+
 ### Relay meta transaction
 Relays a meta transaction to the blockchain.
 #### Request

--- a/src/relay/api/app.py
+++ b/src/relay/api/app.py
@@ -41,6 +41,7 @@ from .resources import (
     Relay,
     RelayMetaTransaction,
     RequestEther,
+    Status,
     TransactionInfos,
     Trustline,
     TrustlineAccruedInterestList,
@@ -164,6 +165,10 @@ def ApiApp(trustlines, *, enabled_apis):
 
     if ApiType.DELEGATE in enabled_apis:
         add_resource(RelayMetaTransaction, "/relay-meta-transaction")
+        add_resource(
+            Status,
+            "/identities/<address:identity_address>/meta-transactions/<string:meta_transaction_hash>/status",
+        )
         add_resource(MetaTransactionFees, "/meta-transaction-fees")
         add_resource(IdentityInfos, "/identities/<address:identity_address>")
         add_resource(Factories, "/factories")

--- a/src/relay/api/fields.py
+++ b/src/relay/api/fields.py
@@ -1,7 +1,7 @@
 import hexbytes
 from eth_utils import is_address, to_checksum_address
 from marshmallow import fields
-from tldeploy.identity import MetaTransaction
+from tldeploy.identity import MetaTransaction, MetaTransactionStatus
 from webargs import ValidationError
 
 from relay.network_graph.payment_path import FeePayer
@@ -94,6 +94,27 @@ class FeePayerField(fields.Field):
             raise ValidationError(
                 f"Could not parse attribute {attr}: {value} has to be one of "
                 f"{[fee_payer.value for fee_payer in FeePayer]}"
+            )
+
+
+class MetaTransactionStatusField(fields.Field):
+    def _serialize(self, value, attr, obj, **kwargs):
+
+        if isinstance(value, MetaTransactionStatus):
+            # serialises into the value of the MetaTransactionStatus enum
+            return value.value
+        else:
+            raise ValidationError("Value must be of type MetaTransactionStatus")
+
+    def _deserialize(self, value, attr, data, **kwargs):
+
+        # deserialize into the MetaTransactionStatus enum instance corresponding to the value
+        try:
+            return MetaTransactionStatus(value)
+        except ValueError:
+            raise ValidationError(
+                f"Could not parse attribute {attr}: {value} has to be one of "
+                f"{[status.value for status in MetaTransactionStatus]}"
             )
 
 

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -39,6 +39,7 @@ from .schemas import (
     IdentityInfosSchema,
     MetaTransactionFeeSchema,
     MetaTransactionSchema,
+    MetaTransactionStatusSchema,
     PaymentPathSchema,
     TrustlineSchema,
     TxInfosSchema,
@@ -490,6 +491,19 @@ class RelayMetaTransaction(Resource):
             return relay_meta_tx(meta_transaction).hex()
         except ValueError:
             abort(409, "There was an error while relaying this meta-transaction")
+
+
+class Status(Resource):
+    def __init__(self, trustlines: TrustlinesRelay) -> None:
+        self.trustlines = trustlines
+
+    @dump_result_with_schema(MetaTransactionStatusSchema())
+    def get(self, identity_address: str, meta_transaction_hash):
+        return {
+            "status": self.trustlines.get_meta_transaction_status(
+                identity_address, meta_transaction_hash
+            )
+        }
 
 
 class MetaTransactionFees(Resource):

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -15,6 +15,7 @@ from .fields import (
     FeePayerField,
     HexBytes,
     HexEncodedBytes,
+    MetaTransactionStatusField,
     OperationTypeField,
 )
 
@@ -77,6 +78,13 @@ class MetaTransactionFeeSchema(Schema):
     gasPrice = BigInteger(required=True, attribute="gas_price")
     feeRecipient = Address(required=True, attribute="fee_recipient")
     currencyNetworkOfFees = Address(required=True, attribute="currency_network_of_fees")
+
+
+class MetaTransactionStatusSchema(Schema):
+    class Meta:
+        strict = True
+
+    status = MetaTransactionStatusField(required=True)
 
 
 class EventSchema(Schema):

--- a/src/relay/blockchain/delegate.py
+++ b/src/relay/blockchain/delegate.py
@@ -151,6 +151,9 @@ class Delegate:
         else:
             raise RuntimeError(f"Unexpected rpc gas price value: {raw_value}")
 
+    def get_meta_transaction_status(self, identity_address, hash):
+        return self.delegate.get_meta_transaction_status(identity_address, hash)
+
 
 class InvalidIdentityContractException(Exception):
     pass

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -259,6 +259,9 @@ class TrustlinesRelay:
     def delegate_meta_transaction(self, meta_transaction: MetaTransaction):
         return self.delegate.send_signed_meta_transaction(meta_transaction)
 
+    def get_meta_transaction_status(self, identity_address, hash):
+        return self.delegate.get_meta_transaction_status(identity_address, hash)
+
     def meta_transaction_fees(self, meta_transaction: MetaTransaction):
         return self.delegate.calculate_fees_for_meta_transaction(meta_transaction)
 


### PR DESCRIPTION
I don't know if I should use a schema to return the meta transaction status or simply use `MetaTransactionStatusField._serialize` without a schema.

requires: https://github.com/trustlines-protocol/contracts/pull/313