### PR TITLE
Feature/add unique event identifier

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -461,6 +461,7 @@ curl https://relay0.testnet.trustlines.network/api/v1/networks/0xC0B33D88C704455
 #### Response
 | Attribute      | Type   | Description                                                                               |
 |----------------|--------|-------------------------------------------------------------------------------------------|
+| id             | string | Unique identifier of the event                                                            |
 | networkAddress | string | Address of currency network                                                               |
 | blockNumber    | string | Number of block                                                                           |
 | timestamp      | int    | UNIX timestamp                                                                            |
@@ -492,6 +493,7 @@ Following additional attributes for `Transfer` events:
 ```json
 [
 	{
+    "id": "02d68ca44b28a9b649e386101cbfc06cb49e845f",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997877,
 		"timestamp": 1524655432,
@@ -506,7 +508,8 @@ Following additional attributes for `Transfer` events:
 		"interestRateReceived": "1000",
         "isFrozen": false
 	},
-    {
+  {
+    "id": "d45f715b320616d69f6c6c339a71445f6aa7279c",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997877,
 		"timestamp": 1524655432,
@@ -517,6 +520,7 @@ Following additional attributes for `Transfer` events:
 		"transactionId": "0xb141aa3baec4e7151d8bd6ecab46d26b1add131e50bcc517c956a7ac979815cd"
 	},
 	{
+    "id": "078ce34b84d4097cdc4df6a07b9a1392691e5588",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997899,
 		"timestamp": 1524655600,
@@ -532,6 +536,7 @@ Following additional attributes for `Transfer` events:
         "isFrozen": false
 	},
 	{
+    "id": "f3bd2b674f8fcba6516b188a3c02296024b8c806",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 7011809,
 		"timestamp": 1524755036,
@@ -568,6 +573,7 @@ curl https://relay0.testnet.trustlines.network/api/v1/networks/0xC0B33D88C704455
 #### Response
 | Attribute      | Type   | Description                                                                               |
 |----------------|--------|-------------------------------------------------------------------------------------------|
+| id             | string | Unique identifier of the event                                                            |
 | networkAddress | string | Address of currency network                                                               |
 | blockNumber    | string | Number of block                                                                           |
 | timestamp      | int    | UNIX timestamp                                                                            |
@@ -598,6 +604,7 @@ Following additional attributes for `Transfer` events:
 ```json
 [
 	{
+    "id": "563debb3c84d92abeb88402835f3b37335ab1eea",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997877,
 		"timestamp": 1524655432,
@@ -612,7 +619,8 @@ Following additional attributes for `Transfer` events:
 		"interestRateReceived": "1000",
         "isFrozen": false
 	},
-    {
+  {
+    "id": "d23f94b640e946dd95c56396400101b0fd708e21",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997877,
 		"timestamp": 1524655432,
@@ -623,6 +631,7 @@ Following additional attributes for `Transfer` events:
 		"transactionId": "0xb141aa3baec4e7151d8bd6ecab46d26b1add131e50bcc517c956a7ac979815cd"
 	},
 	{
+    "id": "e33e2b34ba734f6b61f2046cc85e9d01d721a616",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997899,
 		"timestamp": 1524655600,
@@ -638,6 +647,7 @@ Following additional attributes for `Transfer` events:
         "isFrozen": false
 	},
 	{
+    "id": "0x05c91f6506e78b1ca2413df9985ca7d37d2da5fc076c0b55c5d9eb9fdd7513a6",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 7011809,
 		"timestamp": 1524755036,

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -91,6 +91,7 @@ class MessageEventSchema(EventSchema):
 
 
 class BlockchainEventSchema(EventSchema):
+    id = HexBytes(attribute="id")
     blockNumber = fields.Integer(attribute="blocknumber")
     type = fields.Str(default="event")
     transactionId = HexBytes(attribute="transaction_id")

--- a/src/relay/blockchain/events.py
+++ b/src/relay/blockchain/events.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import hexbytes
+from eth_hash.auto import keccak
 
 from ..events import Event
 
@@ -11,16 +12,16 @@ class BlockchainEvent(Event):
         self._web3_event = web3_event
         self.blocknumber: Optional[int] = web3_event.get("blockNumber", None)
         self._current_blocknumber = current_blocknumber
-        # NOTE: The field transactionHash is of type HexBytes sind web3 v4. It can also be a hex string because
-        # the indexer currently can not save bytes in the database.
-        # See issue https://github.com/trustlines-protocol/py-eth-index/issues/16
-        self.transaction_id: hexbytes.HexBytes
-        transaction_id = web3_event.get("transactionHash")
-        if not isinstance(transaction_id, hexbytes.HexBytes):
-            self.transaction_id = hexbytes.HexBytes(web3_event.get("transactionHash"))
-        else:
-            self.transaction_id = transaction_id
+        self._block_hash = _parse_block_hash(web3_event)
+        self.transaction_id = _field_to_hexbytes(web3_event.get("transactionHash"))
         self.type = web3_event.get("event")
+        self._log_index = web3_event.get("logIndex")
+
+    @property
+    def id(self) -> hexbytes.HexBytes:
+        return hexbytes.HexBytes(
+            keccak(self.transaction_id + self._block_hash + bytes([self._log_index]))
+        )
 
     @property
     def status(self) -> str:
@@ -69,3 +70,23 @@ class TLNetworkEvent(BlockchainEvent):
             return self.to
         else:
             return self.from_
+
+
+def _parse_block_hash(web3_event) -> hexbytes.HexBytes:
+    block_hash = web3_event.get("blockHash")
+
+    if block_hash is None:
+        block_hash = b"pending"
+
+    return _field_to_hexbytes(block_hash)
+
+
+def _field_to_hexbytes(field_value) -> hexbytes.HexBytes:
+    # NOTE: Some fields are of type HexBytes sind web3 v4. It can also be a hex string because
+    # the indexer currently can not save bytes in the database.
+    # See issue https://github.com/trustlines-protocol/py-eth-index/issues/16
+    if not isinstance(field_value, hexbytes.HexBytes):
+        return hexbytes.HexBytes(field_value)
+
+    else:
+        return field_value

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -1,3 +1,4 @@
+import hexbytes
 import pytest
 
 from relay.blockchain.currency_network_events import (
@@ -6,11 +7,19 @@ from relay.blockchain.currency_network_events import (
     TrustlineUpdateEvent,
     TrustlineUpdateEventType,
 )
+from relay.blockchain.events import BlockchainEvent
 
 
 @pytest.fixture()
 def web3_event():
-    return {"blockNumber": 5, "transactionHash": "0x1234", "address": "0x12345"}
+    return {
+        "blockNumber": 5,
+        "blockHash": "0xd74c3e8bdb19337987b987aee0fa48ed43f8f2318edfc84e3a8643e009592a68",
+        "transactionHash": "0x1234",
+        "address": "0x12345",
+        "event": "TestEvent",
+        "logIndex": 2,
+    }
 
 
 @pytest.fixture()
@@ -44,6 +53,17 @@ def web3_event_transfer(web3_event, test_extra_data):
         }
     )
     return web3_event
+
+
+def test_blockchain_event(web3_event):
+    event = BlockchainEvent(web3_event, 10, 123456)
+
+    assert event.blocknumber == 5
+    assert event.transaction_id == hexbytes.HexBytes("0x1234")
+    assert event.type == "TestEvent"
+    assert event.id == hexbytes.HexBytes(
+        "0x45cc770036e3baccdccae4a22fe6bf66f52d29e97a6f95798966d920bf6cc7ab"
+    )
 
 
 def test_trustline_update_event(web3_event_trustline_update):


### PR DESCRIPTION
Closes: #419

Speciality: events from the pending block will get the artificial block hash `pending`. This makes it stable and create an ID for all events. But is should not be used if the `status` is  `pending`, since the ID **must** change.