### PR TITLE
Fix identity related addresses on laika

### DIFF
--- a/config/addresses_laika.json
+++ b/config/addresses_laika.json
@@ -4,6 +4,6 @@
   "0xEe10359af0bd60E9dbb74007a2c71207Bf2fbD2e",
   "0x8b7072886F672117aF1763DF784bd5c9B2bbee4b"
  ],
- "identityImplementation": "0x7255E01F934307FfB7a41FC78B6b1688f5dc6845",
- "identityProxyFactory": "0xF129765E99EC542bC49C81A9eF6C5fFF10529322"
+ "identityImplementation": "0xe14b9FF5ADeC66142F5a621Cd7BA7Ca84035d47c",
+ "identityProxyFactory": "0x2862ac3efE938Ac6d2bd466Be4842a777818C473"
 }


### PR DESCRIPTION
We somehow managed to deploy the wrong contracts. The new ones have
been installed with the following packages from PyPI:

,----
| contract-deploy-tools==0.7.1
| trustlines-contracts-bin==1.1.0
| trustlines-contracts-deploy==1.1.0
`----