### PR TITLE
Make /networks endpoint faster

### DIFF
--- a/src/relay/blockchain/currency_network_proxy.py
+++ b/src/relay/blockchain/currency_network_proxy.py
@@ -63,25 +63,23 @@ class CurrencyNetworkProxy(Proxy):
         self.interest_rate_decimals = 2
         self.is_frozen = self._proxy.functions.isNetworkFrozen().call()
 
-    @property
-    def users(self) -> List[str]:
+    def fetch_users(self) -> List[str]:
         return list(self._proxy.functions.getUsers().call())
 
-    @property
-    def num_users(self) -> int:
-        return len(self.users)
+    def fetch_num_users(self) -> int:
+        return len(self.fetch_users())
 
-    def friends(self, user_address: str) -> List[str]:
+    def fetch_friends(self, user_address: str) -> List[str]:
         return list(self._proxy.functions.getFriends(user_address).call())
 
-    def account(self, a_address: str, b_address: str):
+    def fetch_account(self, a_address: str, b_address: str):
         return self._proxy.functions.getAccount(a_address, b_address).call()
 
     def gen_graph_representation(self) -> List[Trustline]:
         """Returns the trustlines network as a dict address -> list of Friendships"""
         result = []
-        for user in self.users:
-            for friend in self.friends(user):
+        for user in self.fetch_users():
+            for friend in self.fetch_friends(user):
                 if user < friend:
                     (
                         creditline_ab,
@@ -91,7 +89,7 @@ class CurrencyNetworkProxy(Proxy):
                         is_frozen,
                         mtime,
                         balance_ab,
-                    ) = self.account(user, friend)
+                    ) = self.fetch_account(user, friend)
                     result.append(
                         Trustline(
                             user=user,

--- a/tests/chain_integration/test_currency_network.py
+++ b/tests/chain_integration/test_currency_network.py
@@ -29,21 +29,21 @@ def test_address(currency_network, testnetwork1_address):
 
 
 def test_friends1(currency_network_with_trustlines, accounts):
-    assert set(currency_network_with_trustlines.friends(accounts[0])) == {
+    assert set(currency_network_with_trustlines.fetch_friends(accounts[0])) == {
         accounts[1],
         accounts[4],
     }
 
 
 def test_friends2(currency_network_with_trustlines, accounts):
-    assert set(currency_network_with_trustlines.friends(accounts[1])) == {
+    assert set(currency_network_with_trustlines.fetch_friends(accounts[1])) == {
         accounts[0],
         accounts[2],
     }
 
 
 def test_account1(currency_network_with_trustlines, accounts):
-    assert currency_network_with_trustlines.account(accounts[0], accounts[1]) == [
+    assert currency_network_with_trustlines.fetch_account(accounts[0], accounts[1]) == [
         100,
         150,
         0,
@@ -55,7 +55,7 @@ def test_account1(currency_network_with_trustlines, accounts):
 
 
 def test_account2(currency_network_with_trustlines, accounts):
-    assert currency_network_with_trustlines.account(accounts[2], accounts[3]) == [
+    assert currency_network_with_trustlines.fetch_account(accounts[2], accounts[3]) == [
         300,
         350,
         0,
@@ -67,7 +67,7 @@ def test_account2(currency_network_with_trustlines, accounts):
 
 
 def test_users(currency_network_with_trustlines, accounts):
-    assert currency_network_with_trustlines.users == accounts[0:5]
+    assert currency_network_with_trustlines.fetch_users() == accounts[0:5]
 
 
 def test_gen_graph_representation(currency_network_with_trustlines, accounts):


### PR DESCRIPTION
We were always fetching the users from the chain node when asking for a
network. Make the endpoint faster by using the internal graph representation. This
might be a little outdated, but as we are subscriped to the events it
should only be several seconds old.
We can in the future decide to remove the call to users completly, but i
did not want to add a breaking change now.

Also renamed some methods to make it clearer that they are slow.