### PR TITLE
Make gasprice of delegate transaction configurable

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,6 +40,15 @@ enable = true
 enable = true
 enable_deploy_identity = true
 fees = []
+## Set the maximum allowed gas usage per delegated meta transaction
+max_gas_limit = 1_000_000
+## Supported gas price methods are rpc, fixed, bound
+## rpc: Ask node for gas price
+## fixed: Use fixed value 'gas_price'
+## bound:  Use gas price from node if in bounds ('min_gas_price', 'max_gas_price'), otherwise use bounds
+# gas_price_method = "fixed"
+# gas_price = 1_000_000_000
+
 
 # [account]
 # keystore_path = "path-to-keystor"

--- a/constraints.txt
+++ b/constraints.txt
@@ -110,8 +110,8 @@ toml==0.10.0
 toolz==0.10.0
 tox==3.13.2
 trie==1.4.0
-trustlines-contracts-bin==1.1.0
-trustlines-contracts-deploy==1.1.0
+trustlines-contracts-bin==1.1.2
+trustlines-contracts-deploy==1.1.2
 typed-ast==1.4.0
 typing-extensions==3.7.4
 urllib3==1.25.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ webargs
 gevent
 web3>=4.7.1
 networkx>=2.0
-trustlines-contracts-bin>=1.1.0
-trustlines-contracts-deploy>=1.1.0
+trustlines-contracts-bin>=1.1.2
+trustlines-contracts-deploy>=1.1.2
 sqlalchemy
 eth-utils
 tinyrpc

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -324,6 +324,7 @@ class TrustlinesRelay:
             self.contracts["Identity"]["abi"],
             self.known_identity_factories,
             delegation_fees=delegation_fees,
+            config=self.config["delegate"],
         )
 
     def start(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -23,7 +23,7 @@ def uncommented_example_config_filepath(example_config_filepath, tmp_path):
     with open(example_config_filepath) as file:
         with open(d, "w") as output_file:
             for line in file.readlines():
-                output_file.writelines([line.replace("#", "")])
+                output_file.writelines([line.replace("# ", " ")])
 
     return str(d)
 


### PR DESCRIPTION
Closes #434 
Let the delegate specify a gas price strategy in the config.
Three simple strategies were added: rpc, fixed and minmax

Let the delegate also specify the max gas limit