### PR TITLE
Revert custom event identifier feature

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -461,7 +461,6 @@ curl https://relay0.testnet.trustlines.network/api/v1/networks/0xC0B33D88C704455
 #### Response
 | Attribute      | Type   | Description                                                                               |
 |----------------|--------|-------------------------------------------------------------------------------------------|
-| id             | string | Unique identifier of the event                                                            |
 | networkAddress | string | Address of currency network                                                               |
 | blockNumber    | string | Number of block                                                                           |
 | timestamp      | int    | UNIX timestamp                                                                            |
@@ -493,7 +492,6 @@ Following additional attributes for `Transfer` events:
 ```json
 [
 	{
-    "id": "02d68ca44b28a9b649e386101cbfc06cb49e845f",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997877,
 		"timestamp": 1524655432,
@@ -508,8 +506,7 @@ Following additional attributes for `Transfer` events:
 		"interestRateReceived": "1000",
         "isFrozen": false
 	},
-  {
-    "id": "d45f715b320616d69f6c6c339a71445f6aa7279c",
+    {
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997877,
 		"timestamp": 1524655432,
@@ -520,7 +517,6 @@ Following additional attributes for `Transfer` events:
 		"transactionId": "0xb141aa3baec4e7151d8bd6ecab46d26b1add131e50bcc517c956a7ac979815cd"
 	},
 	{
-    "id": "078ce34b84d4097cdc4df6a07b9a1392691e5588",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997899,
 		"timestamp": 1524655600,
@@ -536,7 +532,6 @@ Following additional attributes for `Transfer` events:
         "isFrozen": false
 	},
 	{
-    "id": "f3bd2b674f8fcba6516b188a3c02296024b8c806",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 7011809,
 		"timestamp": 1524755036,
@@ -573,7 +568,6 @@ curl https://relay0.testnet.trustlines.network/api/v1/networks/0xC0B33D88C704455
 #### Response
 | Attribute      | Type   | Description                                                                               |
 |----------------|--------|-------------------------------------------------------------------------------------------|
-| id             | string | Unique identifier of the event                                                            |
 | networkAddress | string | Address of currency network                                                               |
 | blockNumber    | string | Number of block                                                                           |
 | timestamp      | int    | UNIX timestamp                                                                            |
@@ -604,7 +598,6 @@ Following additional attributes for `Transfer` events:
 ```json
 [
 	{
-    "id": "563debb3c84d92abeb88402835f3b37335ab1eea",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997877,
 		"timestamp": 1524655432,
@@ -619,8 +612,7 @@ Following additional attributes for `Transfer` events:
 		"interestRateReceived": "1000",
         "isFrozen": false
 	},
-  {
-    "id": "d23f94b640e946dd95c56396400101b0fd708e21",
+    {
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997877,
 		"timestamp": 1524655432,
@@ -631,7 +623,6 @@ Following additional attributes for `Transfer` events:
 		"transactionId": "0xb141aa3baec4e7151d8bd6ecab46d26b1add131e50bcc517c956a7ac979815cd"
 	},
 	{
-    "id": "e33e2b34ba734f6b61f2046cc85e9d01d721a616",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 6997899,
 		"timestamp": 1524655600,
@@ -647,7 +638,6 @@ Following additional attributes for `Transfer` events:
         "isFrozen": false
 	},
 	{
-    "id": "0x05c91f6506e78b1ca2413df9985ca7d37d2da5fc076c0b55c5d9eb9fdd7513a6",
 		"networkAddress": "0xC0B33D88C704455075a0724AA167a286da778DDE",
 		"blockNumber": 7011809,
 		"timestamp": 1524755036,

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -91,7 +91,6 @@ class MessageEventSchema(EventSchema):
 
 
 class BlockchainEventSchema(EventSchema):
-    id = HexBytes(attribute="id")
     blockNumber = fields.Integer(attribute="blocknumber")
     type = fields.Str(default="event")
     transactionId = HexBytes(attribute="transaction_id")

--- a/src/relay/blockchain/events.py
+++ b/src/relay/blockchain/events.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import hexbytes
-from eth_hash.auto import keccak
 
 from ..events import Event
 
@@ -12,16 +11,16 @@ class BlockchainEvent(Event):
         self._web3_event = web3_event
         self.blocknumber: Optional[int] = web3_event.get("blockNumber", None)
         self._current_blocknumber = current_blocknumber
-        self._block_hash = _parse_block_hash(web3_event)
-        self.transaction_id = _field_to_hexbytes(web3_event.get("transactionHash"))
+        # NOTE: The field transactionHash is of type HexBytes sind web3 v4. It can also be a hex string because
+        # the indexer currently can not save bytes in the database.
+        # See issue https://github.com/trustlines-protocol/py-eth-index/issues/16
+        self.transaction_id: hexbytes.HexBytes
+        transaction_id = web3_event.get("transactionHash")
+        if not isinstance(transaction_id, hexbytes.HexBytes):
+            self.transaction_id = hexbytes.HexBytes(web3_event.get("transactionHash"))
+        else:
+            self.transaction_id = transaction_id
         self.type = web3_event.get("event")
-        self._log_index = web3_event.get("logIndex")
-
-    @property
-    def id(self) -> hexbytes.HexBytes:
-        return hexbytes.HexBytes(
-            keccak(self.transaction_id + self._block_hash + bytes([self._log_index]))
-        )
 
     @property
     def status(self) -> str:
@@ -70,23 +69,3 @@ class TLNetworkEvent(BlockchainEvent):
             return self.to
         else:
             return self.from_
-
-
-def _parse_block_hash(web3_event) -> hexbytes.HexBytes:
-    block_hash = web3_event.get("blockHash")
-
-    if block_hash is None:
-        block_hash = b"pending"
-
-    return _field_to_hexbytes(block_hash)
-
-
-def _field_to_hexbytes(field_value) -> hexbytes.HexBytes:
-    # NOTE: Some fields are of type HexBytes sind web3 v4. It can also be a hex string because
-    # the indexer currently can not save bytes in the database.
-    # See issue https://github.com/trustlines-protocol/py-eth-index/issues/16
-    if not isinstance(field_value, hexbytes.HexBytes):
-        return hexbytes.HexBytes(field_value)
-
-    else:
-        return field_value

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -1,4 +1,3 @@
-import hexbytes
 import pytest
 
 from relay.blockchain.currency_network_events import (
@@ -7,19 +6,11 @@ from relay.blockchain.currency_network_events import (
     TrustlineUpdateEvent,
     TrustlineUpdateEventType,
 )
-from relay.blockchain.events import BlockchainEvent
 
 
 @pytest.fixture()
 def web3_event():
-    return {
-        "blockNumber": 5,
-        "blockHash": "0xd74c3e8bdb19337987b987aee0fa48ed43f8f2318edfc84e3a8643e009592a68",
-        "transactionHash": "0x1234",
-        "address": "0x12345",
-        "event": "TestEvent",
-        "logIndex": 2,
-    }
+    return {"blockNumber": 5, "transactionHash": "0x1234", "address": "0x12345"}
 
 
 @pytest.fixture()
@@ -53,17 +44,6 @@ def web3_event_transfer(web3_event, test_extra_data):
         }
     )
     return web3_event
-
-
-def test_blockchain_event(web3_event):
-    event = BlockchainEvent(web3_event, 10, 123456)
-
-    assert event.blocknumber == 5
-    assert event.transaction_id == hexbytes.HexBytes("0x1234")
-    assert event.type == "TestEvent"
-    assert event.id == hexbytes.HexBytes(
-        "0x45cc770036e3baccdccae4a22fe6bf66f52d29e97a6f95798966d920bf6cc7ab"
-    )
 
 
 def test_trustline_update_event(web3_event_trustline_update):


### PR DESCRIPTION
During the praxis tests we discovered that the pending events where not
received by the mobile app anymore. During the inspection it turned out
that the event identifier calculation fails for pending events. The log
index is `None` and lead to a failure. Unfortunately this did not occur with the
end-to-end tests.
Since the custom event identifier was never finally implemented and was
still under discussion for pending events, the feature has been
postponed. The thought was that the additional response field does not
hurt since it is not used. But because it lead to issues in the staging
setup, we need to revert it here.

This reverts the commits:
  - a259d02115059b7e942b5faca56089aa2c732850
  - 5d8b99aaa68a21921449dd00cec3a8a1899b4958