### PR TITLE
Expose default relay port for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,5 @@ RUN apt-get update \
 FROM runner
 COPY --from=builder /opt/relay /opt/relay
 WORKDIR /opt/relay
+EXPOSE 5000
 ENTRYPOINT ["tl-relay"]


### PR DESCRIPTION
Closes: #443

That is the only thing I found where the port is not used/set/exposed/... If that wasn't meant by the feedback please simply comment.