### PR TITLE
Improve performance of log listener

### DIFF
--- a/src/relay/blockchain/currency_network_proxy.py
+++ b/src/relay/blockchain/currency_network_proxy.py
@@ -5,6 +5,7 @@ import socket
 from typing import List, NamedTuple
 
 import gevent
+from gevent import Greenlet
 
 import relay.concurrency_utils as concurrency_utils
 
@@ -124,45 +125,67 @@ class CurrencyNetworkProxy(Proxy):
 
         gevent.Greenlet.spawn(sync)
 
-    def start_listen_on_balance(self, on_balance) -> None:
+    def start_listen_on_balance(self, on_balance, *, start_log_filter=True) -> Greenlet:
         def log(log_entry):
             on_balance(self._build_event(log_entry))
 
-        self.start_listen_on(BalanceUpdateEventType, log)
+        return self.start_listen_on(
+            BalanceUpdateEventType, log, start_log_filter=start_log_filter
+        )
 
-    def start_listen_on_trustline(self, on_trustline_change) -> None:
+    def start_listen_on_trustline(
+        self, on_trustline_change, *, start_log_filter=True
+    ) -> Greenlet:
         def log_trustline(log_entry):
             on_trustline_change(self._build_event(log_entry))
 
-        self.start_listen_on(TrustlineUpdateEventType, log_trustline)
+        return self.start_listen_on(
+            TrustlineUpdateEventType, log_trustline, start_log_filter=start_log_filter
+        )
 
-    def start_listen_on_trustline_request(self, on_trustline_request) -> None:
+    def start_listen_on_trustline_request(
+        self, on_trustline_request, *, start_log_filter=True
+    ) -> Greenlet:
         def log_trustline_request(log_entry):
             on_trustline_request(self._build_event(log_entry))
 
-        self.start_listen_on(TrustlineRequestEventType, log_trustline_request)
+        return self.start_listen_on(
+            TrustlineRequestEventType,
+            log_trustline_request,
+            start_log_filter=start_log_filter,
+        )
 
     def start_listen_on_trustline_request_cancel(
-        self, on_trustline_request_cancel
-    ) -> None:
+        self, on_trustline_request_cancel, *, start_log_filter=True
+    ) -> Greenlet:
         def log_trustline_request_cancel(log_entry):
             on_trustline_request_cancel(self._build_event(log_entry))
 
-        self.start_listen_on(
-            TrustlineRequestCancelEventType, log_trustline_request_cancel
+        return self.start_listen_on(
+            TrustlineRequestCancelEventType,
+            log_trustline_request_cancel,
+            start_log_filter=start_log_filter,
         )
 
-    def start_listen_on_transfer(self, on_transfer) -> None:
+    def start_listen_on_transfer(
+        self, on_transfer, *, start_log_filter=True
+    ) -> Greenlet:
         def log(log_entry):
             on_transfer(self._build_event(log_entry))
 
-        self.start_listen_on(TransferEventType, log)
+        return self.start_listen_on(
+            TransferEventType, log, start_log_filter=start_log_filter
+        )
 
-    def start_listen_on_network_freeze(self, on_network_freeze):
+    def start_listen_on_network_freeze(
+        self, on_network_freeze, *, start_log_filter=True
+    ):
         def log(log_entry):
             on_network_freeze(self._build_event(log_entry))
 
-        self.start_listen_on(NetworkFreezeEventType, log)
+        return self.start_listen_on(
+            NetworkFreezeEventType, log, start_log_filter=start_log_filter
+        )
 
     def get_network_events(
         self,

--- a/src/relay/blockchain/exchange_proxy.py
+++ b/src/relay/blockchain/exchange_proxy.py
@@ -70,7 +70,7 @@ class ExchangeProxy(Proxy):
     def get_unavailable_amount(self, order: Order) -> int:
         return self._proxy.functions.getUnavailableTakerTokenAmount(order.hash()).call()
 
-    def start_listen_on_fill(self, f) -> None:
+    def start_listen_on_fill(self, f):
         def log(log_entry):
             f(
                 log_entry["args"]["orderHash"],
@@ -78,7 +78,7 @@ class ExchangeProxy(Proxy):
                 log_entry["args"]["filledTakerTokenAmount"],
             )
 
-        self.start_listen_on(LogFillEventType, log)
+        return self.start_listen_on(LogFillEventType, log)
 
     def start_listen_on_cancel(self, f) -> None:
         def log(log_entry):
@@ -88,7 +88,7 @@ class ExchangeProxy(Proxy):
                 log_entry["args"]["cancelledTakerTokenAmount"],
             )
 
-        self.start_listen_on(LogCancelEventType, log)
+        return self.start_listen_on(LogCancelEventType, log)
 
     def get_exchange_events(
         self,

--- a/src/relay/blockchain/proxy.py
+++ b/src/relay/blockchain/proxy.py
@@ -4,9 +4,15 @@ import logging
 import math
 import socket
 import time
-from typing import Any, Callable, Dict, List, Mapping
+from collections import defaultdict
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set
 
+import eth_utils
 import gevent
+import hexbytes
+from gevent import Greenlet
+from gevent.queue import Queue
+from web3._utils.events import get_event_data
 
 import relay.concurrency_utils as concurrency_utils
 
@@ -30,28 +36,75 @@ def get_new_entries(filter, callback):
 
 
 def watch_filter(filter, callback):
-    while 1:
+    while True:
         get_new_entries(filter, callback)
         gevent.sleep(1.0)
 
 
-class Proxy(object):
-    event_builders: Mapping[str, Callable[[Any, int, int], BlockchainEvent]] = {}
-    standard_event_types: List[str] = []
+class LogFilterListener:
+    """Listens for new logs for several contract proxies and notifies them"""
 
-    def __init__(self, web3, abi, address: str) -> None:
+    def __init__(self, web3, filter_params: Dict[str, Any] = None):
         self._web3 = web3
-        self._proxy = web3.eth.contract(abi=abi, address=address)
-        self.address = address
+        self._proxies: Dict[str, Proxy] = {}
+        self._watch_filter_greenlet = None
+        self.currently_watched_addresses: Set[str] = set()
+        self._filter_params = filter_params
+        if self._filter_params is None:
+            self._filter_params = {}
 
-    def _watch_filter(self, eventname: str, function: Callable, params: Dict = None):
+    def add_proxy(self, proxy: "Proxy"):
+        """Add a new proxy to listen for logs"""
+        self._proxies[proxy.address] = proxy
+
+    def start(self):
+        """Start or restart listening for logs for the currently registered proxies"""
+        proxy_addresses = set(self._proxies.keys())
+        if (
+            self._watch_filter_greenlet is not None
+            and proxy_addresses == self.currently_watched_addresses
+        ):
+            # Nothing to do, everything is running
+            return
+
+        if self._watch_filter_greenlet is not None:
+            self._watch_filter_greenlet.kill()
+
+        self._filter_params.setdefault("fromBlock", updateBlock)
+        self._filter_params.setdefault("toBlock", updateBlock)
+        self._filter_params["address"] = list(proxy_addresses)
+
+        self._watch_filter_greenlet = self._watch_filter(
+            self._process_log, self._filter_params
+        )
+        self.currently_watched_addresses = proxy_addresses
+
+        def on_exception(greenlet):
+            logger.warning(
+                "Filter {} disconnected, trying to reconnect".format(greenlet)
+            )
+            try:
+                greenlet.get()
+            except Exception as e:
+                logger.warning(f"Reason: {e}")
+            gevent.sleep(reconnect_interval)
+            greenlet = self._watch_filter(self._process_log, self._filter_params)
+            greenlet.link_exception(on_exception)
+
+        self._watch_filter_greenlet.link_exception(on_exception)
+        return self
+
+    def stop(self):
+        if self._watch_filter_greenlet is not None:
+            self._watch_filter_greenlet.kill()
+            self._watch_filter_greenlet = None
+
+    def _watch_filter(self, function: Callable, params: Dict):
         while True:
             try:
-                filter = getattr(self._proxy.events, eventname).createFilter(**params)
+                filter = self._web3.eth.filter(params)
                 watch_filter_greenlet = gevent.spawn(watch_filter, filter, function)
-                logger.info(
-                    "Connected to filter for {}:{}".format(self.address, eventname)
-                )
+                logger.info("Connected to filter for {}".format(params["address"]))
                 return watch_filter_greenlet
             except socket.timeout as err:
                 logger.warning(
@@ -69,21 +122,50 @@ class Proxy(object):
                 )
                 gevent.sleep(reconnect_interval)
 
-    def start_listen_on(
-        self, eventname: str, function: Callable, params: Dict = None
-    ) -> None:
-        def on_exception(filter):
-            logger.warning("Filter {} disconnected, trying to reconnect".format(filter))
-            gevent.sleep(reconnect_interval)
-            filter = self._watch_filter(eventname, function, params)
-            filter.link_exception(on_exception)
+    def _process_log(self, log) -> None:
+        self._proxies[log["address"]]._register_raw_event_log(log)
 
-        if params is None:
-            params = {}
-        params.setdefault("fromBlock", updateBlock)
-        params.setdefault("toBlock", updateBlock)
-        watch_filter_greenlet = self._watch_filter(eventname, function, params)
-        watch_filter_greenlet.link_exception(on_exception)
+
+class Proxy(object):
+    event_builders: Mapping[str, Callable[[Any, int, int], BlockchainEvent]] = {}
+    standard_event_types: List[str] = []
+
+    def __init__(self, web3, abi, address: str) -> None:
+        self._web3 = web3
+        self._proxy = web3.eth.contract(abi=abi, address=address)
+        self.address = address
+        self._event2log_queue: Dict[str, Queue] = defaultdict(Queue)
+        self._topic2event_abi = {
+            hexbytes.HexBytes(eth_utils.event_abi_to_log_topic(event_abi)): event_abi
+            for event_abi in self._proxy.events._events
+        }
+        self._log_listener: Optional[LogFilterListener] = None
+
+    def start_listen_on(
+        self, eventname: str, function: Callable, *, start_log_filter=True
+    ) -> Greenlet:
+        """
+        Starts listening for new events with name `eventname` and call the function for every received event
+        if start_log_filter is true, also start a log filter to listen for the logs.
+        """
+        self._event2log_queue[eventname] = Queue()
+
+        def poll_from_queue():
+            try:
+                for event in self._event2log_queue[eventname]:
+                    function(event)
+            except Greenlet.GreenletExit:
+                logger.info("Received kill, shutting down")
+                if self._log_listener is not None:
+                    self._log_listener.stop()
+                    self._log_listener = None
+
+        if start_log_filter and self._log_listener is None:
+            self._log_listener = LogFilterListener(self._web3)
+            self._log_listener.add_proxy(self)
+            self._log_listener.start()
+        watch_filter_greenlet = gevent.spawn(poll_from_queue)
+        return watch_filter_greenlet
 
     def get_events(
         self, event_name, filter_=None, from_block=0, timeout: float = None
@@ -117,6 +199,21 @@ class Proxy(object):
     def _build_events(self, events: List[Any]):
         current_blocknumber = self._web3.eth.blockNumber
         return [self._build_event(event, current_blocknumber) for event in events]
+
+    def _register_raw_event_log(self, raw_event_log) -> None:
+        """Registers a new log to be decoded and sent to the correct event listener"""
+        event = get_event_data(self._get_abi_for_log(raw_event_log), raw_event_log)
+        self._event2log_queue[event.event].put(event)
+
+    def _get_abi_for_log(self, raw_event_log):
+        topic = hexbytes.HexBytes(raw_event_log["topics"][0])
+        event_abi = self._topic2event_abi.get(topic)
+        if event_abi is None:
+            raise RuntimeError(
+                f"Could not find event abi for log {raw_event_log} on contract {self.address}. "
+                "{topic} not in {self._topic2event_abi.keys()}"
+            )
+        return event_abi
 
     def _build_event(
         self, event: Any, current_blocknumber: int = None

--- a/tests/chain_integration/test_exchange_proxy.py
+++ b/tests/chain_integration/test_exchange_proxy.py
@@ -227,7 +227,7 @@ def test_listen_on_fill(order_trustlines, exchange_proxy, testnetworks, maker, t
 
     order = order_trustlines
 
-    exchange_proxy.start_listen_on_fill(log)
+    greenlet = exchange_proxy.start_listen_on_fill(log)
     gevent.sleep(0.001)
 
     exchange_contract = testnetworks[1]
@@ -262,6 +262,8 @@ def test_listen_on_fill(order_trustlines, exchange_proxy, testnetworks, maker, t
     assert log1[1] == 50
     assert log1[2] == 100
 
+    greenlet.kill()
+
 
 def test_listen_on_cancel(order_token, exchange_proxy, testnetworks, maker, taker):
     logs = []
@@ -271,7 +273,7 @@ def test_listen_on_cancel(order_token, exchange_proxy, testnetworks, maker, take
 
     order = order_token
 
-    exchange_proxy.start_listen_on_cancel(log)
+    greenlet = exchange_proxy.start_listen_on_cancel(log)
     gevent.sleep(0.001)
 
     exchange_contract = testnetworks[1]
@@ -300,3 +302,5 @@ def test_listen_on_cancel(order_token, exchange_proxy, testnetworks, maker, take
     assert log1[0] == order.hash()
     assert log1[1] == 50
     assert log1[2] == 100
+
+    greenlet.kill()

--- a/tests/chain_integration/test_graph_integration.py
+++ b/tests/chain_integration/test_graph_integration.py
@@ -9,8 +9,9 @@ from relay.network_graph.graph import CurrencyNetworkGraph
 def link_graph(proxy, graph, full_sync_interval=None):
     if full_sync_interval is not None:
         proxy.start_listen_on_full_sync(_create_on_full_sync(graph), full_sync_interval)
-    proxy.start_listen_on_balance(_create_on_balance(graph))
-    proxy.start_listen_on_trustline(_create_on_trustline(graph))
+    greenlet_balance = proxy.start_listen_on_balance(_create_on_balance(graph))
+    greenlet_trustline = proxy.start_listen_on_trustline(_create_on_trustline(graph))
+    return [greenlet_balance, greenlet_trustline]
 
 
 def _create_on_balance(graph):
@@ -45,16 +46,19 @@ def _create_on_full_sync(graph):
 def community_with_trustlines(currency_network_with_trustlines):
     community = CurrencyNetworkGraph(100)
     community.gen_network(currency_network_with_trustlines.gen_graph_representation())
-    link_graph(currency_network_with_trustlines, community)
-    return community
+    greenlets = link_graph(currency_network_with_trustlines, community)
+    gevent.sleep(0.0001)
+    yield community
+    gevent.killall(greenlets)
 
 
 @pytest.fixture()
 def fresh_community(currency_network):
     community = CurrencyNetworkGraph(100)
-    link_graph(currency_network, community)
+    greenlets = link_graph(currency_network, community)
     gevent.sleep(0.0001)
-    return community
+    yield community
+    gevent.killall(greenlets)
 
 
 def test_path(community_with_trustlines, accounts):


### PR DESCRIPTION
Before we had one log listener for each event on each contract. Now we
use only 1 log listener for all events. This should boost performance.

I tried to not break too much of the proxy class, so thats why I left
the start_listen.. methods.

Closes #445 