### PR TITLE
Feature/delegation fees config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -43,6 +43,8 @@ enable = true
 [delegate]
 enable = true
 enable_deploy_identity = true
+## The list of accepted fees for delegating a meta-tx
+## example for accepting 0 fees: [{'base_fee'=0, 'gas_price'=0}] other keys are 'currency_network' and 'fee_recipient'
 fees = []
 ## Set the maximum allowed gas usage per delegated meta transaction
 max_gas_limit = 1_000_000

--- a/config.toml
+++ b/config.toml
@@ -44,8 +44,10 @@ enable = true
 enable = true
 enable_deploy_identity = true
 ## The list of accepted fees for delegating a meta-tx
-## example for accepting 0 fees: [{'base_fee'=0, 'gas_price'=0}] other keys are 'currency_network' and 'fee_recipient'
-fees = []
+## Below is an example for accepting 0 fees. Other keys are 'currency_network' and 'fee_recipient'
+fees = [
+# {'base_fee'=0, 'gas_price'=0}
+]
 ## Set the maximum allowed gas usage per delegated meta transaction
 max_gas_limit = 1_000_000
 ## Supported gas price methods are rpc, fixed, bound

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -86,7 +86,8 @@ def handle_meta_transaction_exceptions(function_to_call):
         except InvalidDelegationFeesException:
             abort(
                 400,
-                f"Invalid delegation fees: fees too low or not supported currency network of fees",
+                f"Invalid delegation fees: fees too low, not supported currency network of fees, "
+                f"or invalid fee recipient",
             )
         except InvalidTimeLimit:
             abort(400, f"Invalid time limit for meta-tx: {meta_transaction.time_limit}")

--- a/src/relay/blockchain/delegate.py
+++ b/src/relay/blockchain/delegate.py
@@ -102,8 +102,7 @@ class Delegate:
 
     def validate_meta_transaction_fees(self, meta_transaction: MetaTransaction):
         fees_estimations = self._calculate_fees_for_meta_transaction(meta_transaction)
-        if not fees_estimations:
-            return
+
         for fees_estimation in fees_estimations:
             if fees_estimation.base_fee == 0 and fees_estimation.gas_price == 0:
                 return

--- a/src/relay/blockchain/delegate.py
+++ b/src/relay/blockchain/delegate.py
@@ -106,11 +106,16 @@ class Delegate:
         for fees_estimation in fees_estimations:
             if fees_estimation.base_fee == 0 and fees_estimation.gas_price == 0:
                 return
+            # Deprecated: for now accept ZERO_ADDRESS as fee recipient. This will be removed in the future.
             if (
                 fees_estimation.currency_network_of_fees
                 == meta_transaction.currency_network_of_fees
                 and fees_estimation.base_fee <= meta_transaction.base_fee
                 and fees_estimation.gas_price <= meta_transaction.gas_price
+                and (
+                    fees_estimation.fee_recipient == meta_transaction.fee_recipient
+                    or meta_transaction.fee_recipient == ZERO_ADDRESS
+                )
             ):
                 return
 

--- a/src/relay/config/schema.py
+++ b/src/relay/config/schema.py
@@ -26,7 +26,23 @@ class FeeSettingsSchema(Schema):
     base_fee = fields.Integer(missing=0)
     gas_price = fields.Integer(missing=0)
     fee_recipient = AddressField()
-    currency_network = AddressField(required=True)
+    currency_network = AddressField(missing=None)
+
+    @validates_schema
+    def validate_currency_network(self, in_data, **kwargs):
+        base_fee = in_data["base_fee"]
+        gas_price = in_data["gas_price"]
+        currency_network = in_data["currency_network"]
+        if base_fee != 0 or gas_price != 0:
+            if not currency_network:
+                raise ValidationError(
+                    "A currency network has to be set for delegation fees when fees are not zero"
+                )
+        elif base_fee == 0 and gas_price == 0:
+            if currency_network:
+                raise ValidationError(
+                    "When delegation fees are set to 0, no currency network should be set"
+                )
 
 
 class GasPriceComputationSchema(Schema):

--- a/src/relay/config/schema.py
+++ b/src/relay/config/schema.py
@@ -23,8 +23,8 @@ class AddressField(fields.Field):
 
 
 class FeeSettingsSchema(Schema):
-    base_fee = fields.Integer(missing=0)
-    gas_price = fields.Integer(missing=0)
+    base_fee = fields.Integer(required=True)
+    gas_price = fields.Integer(required=True)
     fee_recipient = AddressField()
     currency_network = AddressField(missing=None)
 

--- a/tests/chain_integration/test_delegate.py
+++ b/tests/chain_integration/test_delegate.py
@@ -389,6 +389,33 @@ def test_meta_transaction_fees_invalid_network(
         )
 
 
+def test_meta_transaction_fee_recipient_invalid(
+    delegate_with_one_fees, signed_meta_transaction, owner_key
+):
+    """
+    Check that an exception is raised when validating an meta_transaction with invalid fee recipient
+    """
+
+    delegation_fees = delegate_with_one_fees.calculate_fees_for_meta_transaction(
+        signed_meta_transaction
+    )[0]
+
+    wrong_recipient = signed_meta_transaction.from_
+    assert delegation_fees.fee_recipient != wrong_recipient
+
+    meta_transaction_with_fees = attr.evolve(
+        signed_meta_transaction,
+        base_fee=delegation_fees.base_fee,
+        currency_network_of_fees=delegation_fees.currency_network_of_fees,
+        fee_recipient=wrong_recipient,
+    )
+    signed_meta_transaction_with_fees = meta_transaction_with_fees.signed(owner_key)
+    with pytest.raises(InvalidDelegationFeesException):
+        delegate_with_one_fees.validate_meta_transaction_fees(
+            signed_meta_transaction_with_fees
+        )
+
+
 @pytest.mark.parametrize(
     "gas_price_config, gas_price",
     [

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,6 +29,24 @@ def uncommented_example_config_filepath(example_config_filepath, tmp_path):
     return str(d)
 
 
+@pytest.fixture()
+def correct_fees_config_file(tmp_path):
+    folder = tmp_path / "subfolder"
+    folder.mkdir()
+    file_path = folder / "correct_config.toml"
+    file_path.write_text(
+        "\n".join(
+            (
+                "[delegate]",
+                "enable = true",
+                "enable_deploy_identity = true",
+                "fees=[{'base_fee'=0, 'gas_price'=0}]",
+            )
+        )
+    )
+    return file_path
+
+
 @pytest.mark.parametrize(
     "test_input, expected_output",
     [
@@ -53,3 +71,7 @@ def test_example_file_matches_default_config(example_config_filepath):
 def test_uncommented_default_config_is_valid(uncommented_example_config_filepath):
     """ Test that if you uncomment the not default fields, that the config is valid"""
     load_config(uncommented_example_config_filepath)
+
+
+def test_correct_fee_config_is_valid(correct_fees_config_file):
+    load_config(correct_fees_config_file)


### PR DESCRIPTION
Make config stricter for delegation fees: 
- if fees are 0 then no currency network should be set
- if fees are not 0 then a currency network should be set (to an address, we don't check what)
- if fess are in config, baseFee and gasPrice are required.
Make relay check for feeRecipient which breaks the e2e tests that will be fixed in the clientlib.

Closes https://github.com/trustlines-protocol/relay/issues/456