### PR TITLE
Feature/transfer information

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -811,11 +811,11 @@ The `accuredInterests` is a list with the following elements:
 Returns information about a trustline transfer applied by transaction with given hash.
 #### Request
 ```
-GET /transfers/:txHash/information
+GET /transfers/:txHash
 ```
 #### Example Request
 ```
-curl https://relay0.testnet.trustlines.network/api/v1/transfers/0xC0B33D88C704455075a0724AA167a286da778DDE/information
+curl https://relay0.testnet.trustlines.network/api/v1/transfers/0xC0B33D88C704455075a0724AA167a286da778DDE
 ```
 #### URL Parameters
 | Name         | Type                      | Required | Description                                       |

--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -826,29 +826,29 @@ The response is a an objects with the following elements:
 
 | Attribute        | Type                | JSON Type            | Description                                 |
 | ---------------- | ------------------- | -------------------- | ------------------------------------------- |
-| path             | list of addresses   | array of strings     | path used by the transfer                   |
 | currencyNetwork  | address             | string               | address of the currency network of transfer |
-| valueSent        | BigInteger          | string               | value sent by sender                        |
-| valueReceived    | BigInteger          | string               | valued received by receiver                 |
-| totalFees        | BigInteger          | string               | total fees paid for transfer                |
+| paymentPath      | payment path object | object               | payment path object                         |
 | feesPaid         | list of fees        | array                | list of paid fees along path                |
 
-The `feesPaid` is a list with the following elements:
+The `paymentPath` is an object with the following attributes:
 
-| Attribute    | Type       | JSON Type | Description                                     |
-| ------------ | ---------- | --------- | ----------------------------------------------- |
-| sender       | address    | string    | the sender of the fee                           |
-| receiver     | address    | string    | the receiver of the fee                         |
-| value        | BigInteger | string    | value of the fee in between sender and receiver |
+| Attribute    | Type              | JSON Type        | Description                                      |
+| ------------ | ----------------- | ---------------- | ------------------------------------------------ |
+| fees         | BigInteger        | string           | total network fees paid for the transfer         |
+| path         | list of addresses | array of strings | Path used for the transfer                       |
+| value        | BigInteger        | string           | value transferred                                |
+| feePayer     | string            | string           | who paid the fees, either `sender` or `receiver` |
 #### Example Response
 ```json
 {
-    "path": ["0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce", "0x7Ec3543702FA8F2C7b2bD84C034aAc36C263cA8b", "0x7Ff66eb1A824FF9D1bB7e234a2d3B7A3b0345320"],
     "currencyNetwork": "0xC0B33D88C704455075a0724AA167a286da778DDE",
-    "feesPaid": [{"sender": "0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce", "receiver": "0x7Ec3543702FA8F2C7b2bD84C034aAc36C263cA8b", "value": "1"}],
-    "valueSent": "100",
-    "valueReceived": "99",
-    "totalFees": "1"
+    "paymentPath": {
+        "fees": "1",
+        "path": ["0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce", "0x7Ec3543702FA8F2C7b2bD84C034aAc36C263cA8b", "0x7Ff66eb1A824FF9D1bB7e234a2d3B7A3b0345320"],
+        "value": "100",
+        "feePayer": "sender"
+    },
+    "feesPaid": ["1"]
 }
 ```
 

--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -824,13 +824,14 @@ curl https://relay0.testnet.trustlines.network/api/v1/transfers/0xC0B33D88C70445
 #### Response
 The response is a an objects with the following elements:
 
-| Attribute        | Type                | JSON Type            | Description                   |
-| ---------------- | ------------------- | -------------------- | ----------------------------- |
-| path             | list of addresses   | array of strings     | path used by the transfer     |
-| feesPaid         | list of fees        | array                | list of paid fees along path  |
-| valueSent        | BigInteger          | string               | value sent by sender          |
-| valueReceived    | BigInteger          | string               | valued received by receiver   |
-| totalFees        | BigInteger          | string               | total fees paid for transfer  |
+| Attribute        | Type                | JSON Type            | Description                                 |
+| ---------------- | ------------------- | -------------------- | ------------------------------------------- |
+| path             | list of addresses   | array of strings     | path used by the transfer                   |
+| currencyNetwork  | address             | string               | address of the currency network of transfer |
+| valueSent        | BigInteger          | string               | value sent by sender                        |
+| valueReceived    | BigInteger          | string               | valued received by receiver                 |
+| totalFees        | BigInteger          | string               | total fees paid for transfer                |
+| feesPaid         | list of fees        | array                | list of paid fees along path                |
 
 The `feesPaid` is a list with the following elements:
 
@@ -843,6 +844,7 @@ The `feesPaid` is a list with the following elements:
 ```json
 {
     "path": ["0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce", "0x7Ec3543702FA8F2C7b2bD84C034aAc36C263cA8b", "0x7Ff66eb1A824FF9D1bB7e234a2d3B7A3b0345320"],
+    "currencyNetwork": "0xC0B33D88C704455075a0724AA167a286da778DDE",
     "feesPaid": [{"sender": "0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce", "receiver": "0x7Ec3543702FA8F2C7b2bD84C034aAc36C263cA8b", "value": "1"}],
     "valueSent": "100",
     "valueReceived": "99",

--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -37,6 +37,7 @@ https://relay0.testnet.trustlines.network/api/v1
 - [Events of a user in currency network](#events-of-a-user-in-currency-network)
 - [Accrued interests of user](#accrued-interests-of-user)
 - [Accrued interests of trustline](#accrued-interests-of-trustline)
+- [Information for transfer in transaction](#information-for-transfer-in-transaction)
 ### User context
 - [Events of user in all currency networks](#events-of-user-in-all-currency-networks)
 - [Transaction infos for user](#transaction-infos-for-user)
@@ -801,6 +802,51 @@ The `accuredInterests` is a list with the following elements:
     "accruedInterests": [{"value": 123, "interestRate":  1000, "timestamp": 1579000000}, {"value": 456, "interestRate":  2000, "timestamp": 1579001000}],
     "user": "0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce",
     "counterparty": "0x7Ff66eb1A824FF9D1bB7e234a2d3B7A3b0345320"
+}
+```
+
+---
+
+### Information for transfer in transaction
+Returns information about a trustline transfer applied by transaction with given hash.
+#### Request
+```
+GET /transfers/:txHash/information
+```
+#### Example Request
+```
+curl https://relay0.testnet.trustlines.network/api/v1/transfers/0xC0B33D88C704455075a0724AA167a286da778DDE/information
+```
+#### URL Parameters
+| Name         | Type                      | Required | Description                                       |
+|--------------|---------------------------|----------|---------------------------------------------------|
+| txHash       | string prefixed with "0x" | YES      | Hash of the tx responsible for the transfer       |
+#### Response
+The response is a an objects with the following elements:
+
+| Attribute        | Type                | JSON Type            | Description                   |
+| ---------------- | ------------------- | -------------------- | ----------------------------- |
+| path             | list of addresses   | array of strings     | path used by the transfer     |
+| feesPaid         | list of fees        | array                | list of paid fees along path  |
+| valueSent        | BigInteger          | string               | value sent by sender          |
+| valueReceived    | BigInteger          | string               | valued received by receiver   |
+| totalFees        | BigInteger          | string               | total fees paid for transfer  |
+
+The `feesPaid` is a list with the following elements:
+
+| Attribute    | Type       | JSON Type | Description                                     |
+| ------------ | ---------- | --------- | ----------------------------------------------- |
+| sender       | address    | string    | the sender of the fee                           |
+| receiver     | address    | string    | the receiver of the fee                         |
+| value        | BigInteger | string    | value of the fee in between sender and receiver |
+#### Example Response
+```json
+{
+    "path": ["0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce", "0x7Ec3543702FA8F2C7b2bD84C034aAc36C263cA8b", "0x7Ff66eb1A824FF9D1bB7e234a2d3B7A3b0345320"],
+    "feesPaid": [{"sender": "0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce", "receiver": "0x7Ec3543702FA8F2C7b2bD84C034aAc36C263cA8b", "value": "1"}],
+    "valueSent": "100",
+    "valueReceived": "99",
+    "totalFees": "1"
 }
 ```
 

--- a/src/relay/api/app.py
+++ b/src/relay/api/app.py
@@ -118,7 +118,7 @@ def ApiApp(trustlines, *, enabled_apis):
             "/networks/<address:network_address>/users/<address:user_address>/"
             "interests/<address:counterparty_address>",
         )
-        add_resource(TransferInformation, "/transfers/<string:tx_hash>/information")
+        add_resource(TransferInformation, "/transfers/<string:tx_hash>")
         add_resource(
             User, "/networks/<address:network_address>/users/<address:user_address>"
         )

--- a/src/relay/api/app.py
+++ b/src/relay/api/app.py
@@ -45,7 +45,7 @@ from .resources import (
     Status,
     TransactionInfos,
     TransactionStatus,
-    TransferInformationSchema,
+    TransferInformation,
     Trustline,
     TrustlineAccruedInterestList,
     TrustlineList,
@@ -118,9 +118,7 @@ def ApiApp(trustlines, *, enabled_apis):
             "/networks/<address:network_address>/users/<address:user_address>/"
             "interests/<address:counterparty_address>",
         )
-        add_resource(
-            TransferInformationSchema, "/transfers/<string:tx_hash>/information"
-        )
+        add_resource(TransferInformation, "/transfers/<string:tx_hash>/information")
         add_resource(
             User, "/networks/<address:network_address>/users/<address:user_address>"
         )

--- a/src/relay/api/app.py
+++ b/src/relay/api/app.py
@@ -45,7 +45,7 @@ from .resources import (
     Status,
     TransactionInfos,
     TransactionStatus,
-    TransferInformation,
+    TransferInformationSchema,
     Trustline,
     TrustlineAccruedInterestList,
     TrustlineList,
@@ -118,7 +118,9 @@ def ApiApp(trustlines, *, enabled_apis):
             "/networks/<address:network_address>/users/<address:user_address>/"
             "interests/<address:counterparty_address>",
         )
-        add_resource(TransferInformation, "/transfers/<string:tx_hash>/information")
+        add_resource(
+            TransferInformationSchema, "/transfers/<string:tx_hash>/information"
+        )
         add_resource(
             User, "/networks/<address:network_address>/users/<address:user_address>"
         )

--- a/src/relay/api/app.py
+++ b/src/relay/api/app.py
@@ -45,6 +45,7 @@ from .resources import (
     Status,
     TransactionInfos,
     TransactionStatus,
+    TransferInformation,
     Trustline,
     TrustlineAccruedInterestList,
     TrustlineList,
@@ -117,6 +118,7 @@ def ApiApp(trustlines, *, enabled_apis):
             "/networks/<address:network_address>/users/<address:user_address>/"
             "interests/<address:counterparty_address>",
         )
+        add_resource(TransferInformation, "/transfers/<string:tx_hash>/information")
         add_resource(
             User, "/networks/<address:network_address>/users/<address:user_address>"
         )

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -42,6 +42,7 @@ from .schemas import (
     MetaTransactionStatusSchema,
     PaymentPathSchema,
     TransactionStatusSchema,
+    TransferInformation,
     TrustlineSchema,
     TxInfosSchema,
     UserCurrencyNetworkEventSchema,
@@ -465,6 +466,15 @@ class TrustlineAccruedInterestList(Resource):
             "user": user_address,
             "counterparty": counterparty_address,
         }
+
+
+class TransferInformation(Resource):
+    def __init__(self, trustlines: TrustlinesRelay) -> None:
+        self.trustlines = trustlines
+
+    @dump_result_with_schema(TransferInformation())
+    def get(self, tx_hash: str):
+        return {"path": self.trustlines.get_transfer_information(tx_hash)}
 
 
 class TransactionInfos(Resource):

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -42,7 +42,7 @@ from .schemas import (
     MetaTransactionStatusSchema,
     PaymentPathSchema,
     TransactionStatusSchema,
-    TransferInformation,
+    TransferInformationSchema,
     TrustlineSchema,
     TxInfosSchema,
     UserCurrencyNetworkEventSchema,
@@ -472,9 +472,9 @@ class TransferInformation(Resource):
     def __init__(self, trustlines: TrustlinesRelay) -> None:
         self.trustlines = trustlines
 
-    @dump_result_with_schema(TransferInformation())
+    @dump_result_with_schema(TransferInformationSchema())
     def get(self, tx_hash: str):
-        return {"path": self.trustlines.get_transfer_information(tx_hash).path}
+        return self.trustlines.get_transfer_information(tx_hash)
 
 
 class TransactionInfos(Resource):

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -474,6 +474,7 @@ class TransferInformation(Resource):
 
     @dump_result_with_schema(TransferInformationSchema())
     def get(self, tx_hash: str):
+        logger.info(self.trustlines.get_transfer_information(tx_hash))
         return self.trustlines.get_transfer_information(tx_hash)
 
 

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -474,7 +474,7 @@ class TransferInformation(Resource):
 
     @dump_result_with_schema(TransferInformation())
     def get(self, tx_hash: str):
-        return {"path": self.trustlines.get_transfer_information(tx_hash)}
+        return {"path": self.trustlines.get_transfer_information(tx_hash).path}
 
 
 class TransactionInfos(Resource):

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -275,7 +275,8 @@ class PaidFeesSchema(Schema):
 class TransferInformationSchema(Schema):
 
     path = Address(many=True)
-    feesPaid = fields.Nested(PaidFeesSchema, many=True)
+    currencyNetwork = Address(attribute="currency_network")
     valueSent = BigInteger(attribute="value_sent")
     valueReceived = BigInteger(attribute="value_received")
     totalFees = BigInteger(attribute="total_fees")
+    feesPaid = fields.Nested(PaidFeesSchema, many=True, attribute="fees_paid")

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -269,13 +269,13 @@ class AccruedInterestListSchema(Schema):
 class PaidFeesSchema(Schema):
     sender = Address()
     receiver = Address()
-    value = fields.Int()
+    value = BigInteger()
 
 
 class TransferInformationSchema(Schema):
 
     path = Address(many=True)
     feesPaid = fields.Nested(PaidFeesSchema, many=True)
-    valueSent = fields.Int(attribute="value_sent")
-    valueReceived = fields.Int(attribute="value_received")
-    totalFees = fields.Int(attribute="total_fees")
+    valueSent = BigInteger(attribute="value_sent")
+    valueReceived = BigInteger(attribute="value_received")
+    totalFees = BigInteger(attribute="total_fees")

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -274,9 +274,6 @@ class PaidFeesSchema(Schema):
 
 class TransferInformationSchema(Schema):
 
-    path = Address(many=True)
     currencyNetwork = Address(attribute="currency_network")
-    valueSent = BigInteger(attribute="value_sent")
-    valueReceived = BigInteger(attribute="value_received")
-    totalFees = BigInteger(attribute="total_fees")
-    feesPaid = fields.Nested(PaidFeesSchema, many=True, attribute="fees_paid")
+    paymentPath = fields.Nested(PaymentPathSchema, attribute="payment_path")
+    feesPaid = BigInteger(many=True, attribute="fees_paid")

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -274,6 +274,9 @@ class PaidFeesSchema(Schema):
 
 class TransferInformationSchema(Schema):
 
-    currencyNetwork = Address(attribute="currency_network")
-    paymentPath = fields.Nested(PaymentPathSchema, attribute="payment_path")
-    feesPaid = BigInteger(many=True, attribute="fees_paid")
+    currencyNetwork = Address(required=True, attribute="currency_network")
+    path = fields.List(Address(), required=True)
+    value = BigInteger(required=True)
+    feePayer = FeePayerField(required=True, attribute="fee_payer")
+    totalFees = BigInteger(required=True, attribute="total_fees")
+    feesPaid = fields.List(BigInteger(), required=True, attribute="fees_paid")

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -266,6 +266,16 @@ class AccruedInterestListSchema(Schema):
     counterparty = Address()
 
 
-class TransferInformation(Schema):
+class PaidFeesSchema(Schema):
+    sender = Address()
+    receiver = Address()
+    value = fields.Int()
+
+
+class TransferInformationSchema(Schema):
 
     path = Address(many=True)
+    feesPaid = fields.Nested(PaidFeesSchema, many=True)
+    valueSent = fields.Int(attribute="value_sent")
+    valueReceived = fields.Int(attribute="value_received")
+    totalFees = fields.Int(attribute="total_fees")

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -264,3 +264,8 @@ class AccruedInterestListSchema(Schema):
     accruedInterests = fields.Nested(AccruedInterestSchema, many=True)
     user = Address()
     counterparty = Address()
+
+
+class TransferInformation(Schema):
+
+    path = Address(many=True)

--- a/src/relay/blockchain/currency_network_proxy.py
+++ b/src/relay/blockchain/currency_network_proxy.py
@@ -329,3 +329,18 @@ class CurrencyNetworkProxy(Proxy):
         ]
         results = concurrency_utils.joinall(queries, timeout=timeout)
         return sorted_events(list(itertools.chain.from_iterable(results)))
+
+    def get_all_transaction_events(self, tx_hash: str, from_block: int = 0):
+
+        filter = {"txHash": tx_hash}
+
+        events = self.get_all_events(filter, from_block)
+
+        logger.debug(
+            "get_all_transaction_events(%s, %s) -> %s rows",
+            tx_hash,
+            from_block,
+            len(events),
+        )
+
+        return events

--- a/src/relay/blockchain/currency_network_proxy.py
+++ b/src/relay/blockchain/currency_network_proxy.py
@@ -6,7 +6,6 @@ from typing import List, NamedTuple
 
 import gevent
 from gevent import Greenlet
-from web3._utils.events import get_event_data
 
 import relay.concurrency_utils as concurrency_utils
 
@@ -23,7 +22,7 @@ from .currency_network_events import (
     standard_event_types,
 )
 from .events import BlockchainEvent
-from .proxy import AbiNotFoundException, Proxy, reconnect_interval, sorted_events
+from .proxy import Proxy, reconnect_interval, sorted_events
 
 
 class Trustline(NamedTuple):
@@ -330,23 +329,3 @@ class CurrencyNetworkProxy(Proxy):
         ]
         results = concurrency_utils.joinall(queries, timeout=timeout)
         return sorted_events(list(itertools.chain.from_iterable(results)))
-
-    def get_all_known_abi_transaction_events(self, tx_hash: str, from_block: int = 0):
-        receipt = self._web3.eth.getTransactionReceipt(tx_hash)
-        events = []
-        for log in receipt["logs"]:
-            try:
-                abi = self._get_abi_for_log(log)
-                rich_log = get_event_data(abi, log)
-                events.append(rich_log)
-            except AbiNotFoundException:
-                pass
-
-        logger.debug(
-            "get_all_known_abi_transaction_events(%s, %s) -> %s rows",
-            tx_hash,
-            from_block,
-            len(events),
-        )
-
-        return sorted_events(self._build_events(events))

--- a/src/relay/blockchain/events.py
+++ b/src/relay/blockchain/events.py
@@ -21,6 +21,7 @@ class BlockchainEvent(Event):
         else:
             self.transaction_id = transaction_id
         self.type = web3_event.get("event")
+        self.log_index = web3_event.get("logIndex")
 
     @property
     def status(self) -> str:

--- a/src/relay/blockchain/events_informations.py
+++ b/src/relay/blockchain/events_informations.py
@@ -154,7 +154,9 @@ class EventsInformationFetcher:
 
     def get_transfer_details(self, tx_hash):
 
-        all_events_of_tx = self.events_proxy.get_all_transaction_events(tx_hash)
+        all_events_of_tx = self.events_proxy.get_all_known_abi_transaction_events(
+            tx_hash
+        )
         transfer_events_in_tx = self.get_all_transfer_events(all_events_of_tx)
         if len(transfer_events_in_tx) == 0:
             raise TransferNotFoundException(tx_hash)

--- a/src/relay/blockchain/events_informations.py
+++ b/src/relay/blockchain/events_informations.py
@@ -11,7 +11,7 @@ from relay.blockchain.currency_network_events import (
     TrustlineUpdateEventType,
 )
 from relay.network_graph.interests import calculate_interests
-from relay.network_graph.payment_path import FeePayer, PaymentPath
+from relay.network_graph.payment_path import FeePayer
 
 logger = logging.getLogger("event_info")
 
@@ -29,7 +29,10 @@ class InterestAccrued:
 @attr.s
 class TransferInformation:
     currency_network = attr.ib()
-    payment_path = attr.ib()
+    path = attr.ib()
+    value = attr.ib()
+    fee_payer = attr.ib()
+    total_fees = attr.ib()
     fees_paid = attr.ib()
 
 
@@ -106,12 +109,10 @@ class EventsInformationFetcher:
 
         return TransferInformation(
             currency_network=currency_network_address,
-            payment_path=PaymentPath(
-                fee=total_fees,
-                path=transfer_path,
-                value=transfer_value,
-                fee_payer=fee_payer,
-            ),
+            path=transfer_path,
+            value=transfer_value,
+            fee_payer=fee_payer,
+            total_fees=total_fees,
             fees_paid=fees_paid,
         )
 

--- a/src/relay/blockchain/events_informations.py
+++ b/src/relay/blockchain/events_informations.py
@@ -38,340 +38,311 @@ class TransferInformation:
     fees_paid = attr.ib()
 
 
-def get_list_of_paid_interests_for_trustline(
-    events_proxy, currency_network_address, user, counterparty
-) -> List[InterestAccrued]:
-    """Get all balance changes of a trustline because of interests and the time at which it occurred."""
-
-    balance_update_events = events_proxy.get_trustline_events(
-        currency_network_address, user, counterparty, event_name=BalanceUpdateEventType
-    )
-    trustline_update_events = events_proxy.get_trustline_events(
-        currency_network_address,
-        user,
-        counterparty,
-        event_name=TrustlineUpdateEventType,
-    )
-
-    return get_accrued_interests_from_events(
-        balance_update_events, trustline_update_events
-    )
-
-
-def get_accrued_interests_from_events(balance_update_events, trustline_update_events):
-    accrued_interests = []
-    for (pre_balance_event, post_balance_event) in toolz.itertoolz.sliding_window(
-        2, balance_update_events
-    ):
-        balance = balance_viewed_from_user(pre_balance_event)
-        interest_rate = get_interests_rates_of_trustline_for_user_before_timestamp(
-            trustline_update_events, balance, post_balance_event.timestamp
-        )
-        interest_value = calculate_interests(
-            balance,
-            interest_rate,
-            post_balance_event.timestamp - pre_balance_event.timestamp,
-        )
-        accrued_interests.append(
-            InterestAccrued(interest_value, interest_rate, post_balance_event.timestamp)
-        )
-
-    return accrued_interests
-
-
-def balance_viewed_from_user(balance_update_event):
-    if balance_update_event.direction == DIRECTION_SENT:
-        return balance_update_event.value
-    elif balance_update_event.direction == DIRECTION_RECEIVED:
-        return -balance_update_event.value
-    else:
-        raise RuntimeError("Unexpected balance update event")
-
-
-def get_interests_rates_of_trustline_for_user_before_timestamp(
-    trustline_update_events, balance, timestamp
-):
-    """Get the interest rate that would be used to apply interests at a certain timestamp"""
-
-    most_recent_event_before_timestamp = None
-    for event in sorted_events(trustline_update_events, reverse=True):
-        if event.timestamp < timestamp:
-            most_recent_event_before_timestamp = event
-            break
-    if most_recent_event_before_timestamp is None:
-        raise RuntimeError("No trustline update event found before given timestamp")
-
-    if most_recent_event_before_timestamp.direction == DIRECTION_SENT:
-        if balance >= 0:
-            return most_recent_event_before_timestamp.interest_rate_given
-        else:
-            return most_recent_event_before_timestamp.interest_rate_received
-    elif most_recent_event_before_timestamp.direction == DIRECTION_RECEIVED:
-        if balance >= 0:
-            return most_recent_event_before_timestamp.interest_rate_received
-        else:
-            return most_recent_event_before_timestamp.interest_rate_given
-    else:
-        raise RuntimeError("Unexpected trustline update event")
-
-
-def sorted_events(events, reverse=False):
-    def key(event):
-        if event.blocknumber is None:
-            return math.inf
-        return event.blocknumber
-
-    return sorted(events, key=key, reverse=reverse)
-
-
-def get_list_of_paid_interests_for_trustline_in_between_timestamps(
-    events_proxy, currency_network_address, user, counterparty, start_time, end_time
-):
-    all_accrued_interests = get_list_of_paid_interests_for_trustline(
-        events_proxy, currency_network_address, user, counterparty
-    )
-    return filter_list_of_accrued_interests_for_time_window(
-        all_accrued_interests, start_time, end_time
-    )
-
-
-def filter_list_of_accrued_interests_for_time_window(
-    accrued_interests: List[InterestAccrued], start_time, end_time
-):
-    filtered_list = []
-    for interest in accrued_interests:
-        if interest.timestamp <= end_time and interest.timestamp >= start_time:
-            filtered_list.append(interest)
-    return filtered_list
-
-
-def get_transfer_details(events_proxy, tx_hash):
-
-    all_events = events_proxy.get_all_transaction_events(tx_hash)
-    transfer_events = get_all_transfer_events(all_events)
-    if len(transfer_events) == 0:
-        raise TransferNotFoundException(tx_hash)
-    if len(transfer_events) > 1:
-        raise MultipleTransferFoundException(tx_hash)
-    transfer_event = transfer_events[0]
-
-    currency_network_address = transfer_event.network_address
-
-    sorted_balance_updates = get_balance_update_events_for_transfer(
-        all_events, transfer_event
-    )
-    delta_balances_along_path = get_delta_balances_of_transfer(
-        events_proxy, currency_network_address, sorted_balance_updates
-    )
-
-    transfer_path = get_transfer_path(sorted_balance_updates)
-
-    fees_paid = get_paid_fees_along_path(transfer_path, delta_balances_along_path)
-
-    return TransferInformation(path=transfer_path, fees_paid=fees_paid)
-
-
-def get_all_transfer_events(all_events):
-    transfer_events = []
-    for event in all_events:
-        if event.type == TransferEventType:
-            transfer_events.append(event)
-    return transfer_events
-
-
-def get_transfer_path(sorted_balance_updates):
-    """Returns the transfer path of the given transfer without the sender"""
-    path_from_events = []
-    path_from_events.append(sorted_balance_updates[0].from_)
-    for event in sorted_balance_updates:
-        path_from_events.append(event.to)
-
-    return path_from_events
-
-
-def get_balance_update_events_for_transfer(all_events, transfer_event):
-    """Returns all balance update events in the correct order that belongs to the transfer event"""
-    log_index = transfer_event.log_index
-    sender = transfer_event.from_
-    receiver = transfer_event.to
-
-    balance_events = []
-    saw_sender_event = False
-    saw_receiver_event = False
-
-    # Search backwards for releated BalanceUpdate events
-    for i in range(log_index - 1, -1, -1):
-        for event in all_events:
-            if event.log_index == i:
-                assert (
-                    event.type == BalanceUpdateEventType
-                ), "Wrong event type for events before transfer event"
-                balance_events.append(event)
-                if event.to == receiver:
-                    saw_receiver_event = True
-                if event.from_ == sender:
-                    saw_sender_event = True
-                break
-        if saw_sender_event and saw_receiver_event:
-            break
-    else:
-        assert False, "Could not find all BalanceUpdate events"
-
-    if balance_events[0].from_ != sender:
-        # For the sender pays case, they are reverse
-        balance_events.reverse()
-
-    assert balance_events[0].from_ == sender
-    assert balance_events[-1].to == receiver
-    return balance_events
-
-
-def get_paid_fees_along_path(transfer_path, delta_balances):
-    fees_values = delta_balances[1:-1]
-    fees_paid = []
-    for sender, receiver in zip(transfer_path[:-2], transfer_path[1:-1]):
-        fees_paid.append(FeesPaid(sender, receiver, fees_values[len(fees_paid)]))
-    return fees_paid
-
-
-def get_delta_balances_of_transfer(
-    events_proxy, currency_network_address, sorted_balance_updates
-):
-    """Returns the balance changes along the path because of a given transfer"""
-    post_balances = []
-    for event in sorted_balance_updates:
-        post_balances.append(event.value)
-
-    pre_balances = []
-    for event in sorted_balance_updates:
-        from_ = event.from_
-        to = event.to
-        pre_balance = get_previous_balance(
-            events_proxy, currency_network_address, from_, to, event
-        )
-        pre_balances.append(pre_balance)
-
-    interests = []
-    for event in sorted_balance_updates:
-        interest = get_interest_at(events_proxy, currency_network_address, event)
-        interests.append(interest)
-
-    # sender balance change
-    delta_balances = [post_balances[0] - pre_balances[0] - interests[0]]
-
-    # mediator balance changes
-    for i in range(len(sorted_balance_updates) - 1):
-        next_tl_balance_change = (
-            post_balances[i + 1] - pre_balances[i + 1] - interests[i + 1]
-        )
-        previous_tl_balance_change = post_balances[i] - pre_balances[i] - interests[i]
-        delta_balances.append(next_tl_balance_change - previous_tl_balance_change)
-
-    # receiver balance change
-    delta_balances.append(-(post_balances[-1] - pre_balances[-1] - interests[-1]))
-
-    return delta_balances
-
-
-def get_previous_balance(
-    events_proxy, currency_network_address, a, b, balance_update_event
-):
-    """Returns the balance before a given balance update event"""
-    balance_update_events = get_all_balance_update_events_for_trustline(
-        events_proxy, currency_network_address, a, b
-    )
-
-    # find the corresponding event
-    for i, event in enumerate(balance_update_events):
-        if event_id(balance_update_event) == event_id(event):
-            index = i
-            break
-    else:
-        raise RuntimeError("Could not find balance update")
-    index -= 1
-
-    if index < 0:
-        return 0
-
-    return get_all_balances_for_trustline(events_proxy, currency_network_address, a, b)[
-        index
-    ]
-
-
-def get_all_balance_update_events_for_trustline(
-    events_proxy, currency_network_address, a, b
-):
-    """Get all balance update events of a trustline in sorted order"""
-    return events_proxy.get_trustline_events(
-        event_name=BalanceUpdateEventType,
-        user_address=a,
-        counterparty_address=b,
-        contract_address=currency_network_address,
-    )
-
-
-def event_id(event):
-    return event.transaction_id, event.log_index  # , event["blockHash"]
-
-
-def get_all_balances_for_trustline(events_proxy, currency_network_address, a, b):
-    """Get all balances of a trustline in sorted order from the view of a"""
-    balance_update_events = get_all_balance_update_events_for_trustline(
-        events_proxy, currency_network_address, a, b
-    )
-
-    def balance(balance_update_event):
-        if balance_update_event.from_ == a and balance_update_event.to == b:
-            return balance_update_event.value
-        elif balance_update_event.from_ == b and balance_update_event.to == a:
-            return -balance_update_event.value
-        else:
-            RuntimeError("Unexpected balance update event")
-
-    return [balance(event) for event in balance_update_events]
-
-
-def get_interest_at(events_proxy, currency_network_address, balance_update_event):
-    """Returns the applied interests at a given balance update"""
-    from_ = balance_update_event.from_
-    to = balance_update_event.to
-    timestamp = balance_update_event.timestamp
-
-    accrued_interests = get_list_of_paid_interests_for_trustline(
-        events_proxy, currency_network_address, from_, to
-    )
-
-    for accrued_interest in accrued_interests:
-        if accrued_interest.timestamp == timestamp:
-            return accrued_interest.value
-    return 0
-
-
-def get_interests_for_trustline(events_proxy, currency_network_address, a, b):
-    """Get all balance changes of a trustline because of interests"""
-    balance_update_events = get_all_balance_update_events_for_trustline(
-        events_proxy, currency_network_address, a, b
-    )
-
-    timestamps = [
-        balance_update_event.timestamp for balance_update_event in balance_update_events
-    ]
-
-    balances = get_all_balances_for_trustline(
-        events_proxy, currency_network_address, a, b
-    )
-
-    return [
-        calculate_interests(balance, post_time - pre_time)
-        for (balance, pre_time, post_time) in zip(
-            balances[:-1], timestamps[:-1], timestamps[1:]
-        )
-    ]
-
-
-class EventsInformation:
+class EventsInformationFetcher:
     def __init__(self, events_proxy):
         self.events_proxy = events_proxy
+
+    def get_list_of_paid_interests_for_trustline(
+        self, currency_network_address, user, counterparty
+    ) -> List[InterestAccrued]:
+        """Get all balance changes of a trustline because of interests and the time at which it occurred."""
+
+        balance_update_events = self.events_proxy.get_trustline_events(
+            currency_network_address,
+            user,
+            counterparty,
+            event_name=BalanceUpdateEventType,
+        )
+        trustline_update_events = self.events_proxy.get_trustline_events(
+            currency_network_address,
+            user,
+            counterparty,
+            event_name=TrustlineUpdateEventType,
+        )
+
+        return self.get_accrued_interests_from_events(
+            balance_update_events, trustline_update_events
+        )
+
+    def get_accrued_interests_from_events(
+        self, balance_update_events, trustline_update_events
+    ):
+        accrued_interests = []
+        for (pre_balance_event, post_balance_event) in toolz.itertoolz.sliding_window(
+            2, balance_update_events
+        ):
+            balance = self.balance_viewed_from_user(pre_balance_event)
+            interest_rate = self.get_interests_rates_of_trustline_for_user_before_timestamp(
+                trustline_update_events, balance, post_balance_event.timestamp
+            )
+            interest_value = calculate_interests(
+                balance,
+                interest_rate,
+                post_balance_event.timestamp - pre_balance_event.timestamp,
+            )
+            accrued_interests.append(
+                InterestAccrued(
+                    interest_value, interest_rate, post_balance_event.timestamp
+                )
+            )
+
+        return accrued_interests
+
+    def balance_viewed_from_user(self, balance_update_event):
+        if balance_update_event.direction == DIRECTION_SENT:
+            return balance_update_event.value
+        elif balance_update_event.direction == DIRECTION_RECEIVED:
+            return -balance_update_event.value
+        else:
+            raise RuntimeError("Unexpected balance update event")
+
+    def get_interests_rates_of_trustline_for_user_before_timestamp(
+        self, trustline_update_events, balance, timestamp
+    ):
+        """Get the interest rate that would be used to apply interests at a certain timestamp"""
+
+        most_recent_event_before_timestamp = None
+        for event in self.sorted_events(trustline_update_events, reverse=True):
+            if event.timestamp < timestamp:
+                most_recent_event_before_timestamp = event
+                break
+        if most_recent_event_before_timestamp is None:
+            raise RuntimeError("No trustline update event found before given timestamp")
+
+        if most_recent_event_before_timestamp.direction == DIRECTION_SENT:
+            if balance >= 0:
+                return most_recent_event_before_timestamp.interest_rate_given
+            else:
+                return most_recent_event_before_timestamp.interest_rate_received
+        elif most_recent_event_before_timestamp.direction == DIRECTION_RECEIVED:
+            if balance >= 0:
+                return most_recent_event_before_timestamp.interest_rate_received
+            else:
+                return most_recent_event_before_timestamp.interest_rate_given
+        else:
+            raise RuntimeError("Unexpected trustline update event")
+
+    def sorted_events(self, events, reverse=False):
+        def key(event):
+            if event.blocknumber is None:
+                return math.inf
+            return event.blocknumber
+
+        return sorted(events, key=key, reverse=reverse)
+
+    def get_list_of_paid_interests_for_trustline_in_between_timestamps(
+        self, currency_network_address, user, counterparty, start_time, end_time
+    ):
+        all_accrued_interests = self.get_list_of_paid_interests_for_trustline(
+            currency_network_address, user, counterparty
+        )
+        return self.filter_list_of_accrued_interests_for_time_window(
+            all_accrued_interests, start_time, end_time
+        )
+
+    def filter_list_of_accrued_interests_for_time_window(
+        self, accrued_interests: List[InterestAccrued], start_time, end_time
+    ):
+        filtered_list = []
+        for interest in accrued_interests:
+            if interest.timestamp <= end_time and interest.timestamp >= start_time:
+                filtered_list.append(interest)
+        return filtered_list
+
+    def get_transfer_details(self, tx_hash):
+
+        all_events = self.events_proxy.get_all_transaction_events(tx_hash)
+        transfer_events = self.get_all_transfer_events(all_events)
+        if len(transfer_events) == 0:
+            raise TransferNotFoundException(tx_hash)
+        if len(transfer_events) > 1:
+            raise MultipleTransferFoundException(tx_hash)
+        transfer_event = transfer_events[0]
+
+        currency_network_address = transfer_event.network_address
+
+        sorted_balance_updates = self.get_balance_update_events_for_transfer(
+            all_events, transfer_event
+        )
+        delta_balances_along_path = self.get_delta_balances_of_transfer(
+            currency_network_address, sorted_balance_updates
+        )
+
+        transfer_path = self.get_transfer_path(sorted_balance_updates)
+
+        fees_paid = self.get_paid_fees_along_path(
+            transfer_path, delta_balances_along_path
+        )
+
+        return TransferInformation(path=transfer_path, fees_paid=fees_paid)
+
+    def get_all_transfer_events(self, all_events):
+        transfer_events = []
+        for event in all_events:
+            if event.type == TransferEventType:
+                transfer_events.append(event)
+        return transfer_events
+
+    def get_transfer_path(self, sorted_balance_updates):
+        """Returns the transfer path of the given transfer without the sender"""
+        path_from_events = []
+        path_from_events.append(sorted_balance_updates[0].from_)
+        for event in sorted_balance_updates:
+            path_from_events.append(event.to)
+
+        return path_from_events
+
+    def get_balance_update_events_for_transfer(self, all_events, transfer_event):
+        """Returns all balance update events in the correct order that belongs to the transfer event"""
+        log_index = transfer_event.log_index
+        sender = transfer_event.from_
+        receiver = transfer_event.to
+
+        balance_events = []
+        saw_sender_event = False
+        saw_receiver_event = False
+
+        # Search backwards for releated BalanceUpdate events
+        for i in range(log_index - 1, -1, -1):
+            for event in all_events:
+                if event.log_index == i:
+                    assert (
+                        event.type == BalanceUpdateEventType
+                    ), "Wrong event type for events before transfer event"
+                    balance_events.append(event)
+                    if event.to == receiver:
+                        saw_receiver_event = True
+                    if event.from_ == sender:
+                        saw_sender_event = True
+                    break
+            if saw_sender_event and saw_receiver_event:
+                break
+        else:
+            assert False, "Could not find all BalanceUpdate events"
+
+        if balance_events[0].from_ != sender:
+            # For the sender pays case, they are reverse
+            balance_events.reverse()
+
+        assert balance_events[0].from_ == sender
+        assert balance_events[-1].to == receiver
+        return balance_events
+
+    def get_paid_fees_along_path(self, transfer_path, delta_balances):
+        fees_values = delta_balances[1:-1]
+        fees_paid = []
+        for sender, receiver in zip(transfer_path[:-2], transfer_path[1:-1]):
+            fees_paid.append(FeesPaid(sender, receiver, fees_values[len(fees_paid)]))
+        return fees_paid
+
+    def get_delta_balances_of_transfer(
+        self, currency_network_address, sorted_balance_updates
+    ):
+        """Returns the balance changes along the path because of a given transfer"""
+        post_balances = []
+        for event in sorted_balance_updates:
+            post_balances.append(event.value)
+
+        pre_balances = []
+        for event in sorted_balance_updates:
+            from_ = event.from_
+            to = event.to
+            pre_balance = self.get_previous_balance(
+                currency_network_address, from_, to, event
+            )
+            pre_balances.append(pre_balance)
+
+        interests = []
+        for event in sorted_balance_updates:
+            interest = self.get_interest_at(currency_network_address, event)
+            interests.append(interest)
+
+        # sender balance change
+        delta_balances = [post_balances[0] - pre_balances[0] - interests[0]]
+
+        # mediator balance changes
+        for i in range(len(sorted_balance_updates) - 1):
+            next_tl_balance_change = (
+                post_balances[i + 1] - pre_balances[i + 1] - interests[i + 1]
+            )
+            previous_tl_balance_change = (
+                post_balances[i] - pre_balances[i] - interests[i]
+            )
+            delta_balances.append(next_tl_balance_change - previous_tl_balance_change)
+
+        # receiver balance change
+        delta_balances.append(-(post_balances[-1] - pre_balances[-1] - interests[-1]))
+
+        return delta_balances
+
+    def get_previous_balance(
+        self, currency_network_address, a, b, balance_update_event
+    ):
+        """Returns the balance before a given balance update event"""
+        balance_update_events = self.get_all_balance_update_events_for_trustline(
+            currency_network_address, a, b
+        )
+
+        # find the corresponding event
+        for i, event in enumerate(balance_update_events):
+            if self.event_id(balance_update_event) == self.event_id(event):
+                index = i
+                break
+        else:
+            raise RuntimeError("Could not find balance update")
+        index -= 1
+
+        if index < 0:
+            return 0
+
+        return self.get_all_balances_for_trustline(currency_network_address, a, b)[
+            index
+        ]
+
+    def get_all_balance_update_events_for_trustline(
+        self, currency_network_address, a, b
+    ):
+        """Get all balance update events of a trustline in sorted order"""
+        return self.events_proxy.get_trustline_events(
+            event_name=BalanceUpdateEventType,
+            user_address=a,
+            counterparty_address=b,
+            contract_address=currency_network_address,
+        )
+
+    def event_id(self, event):
+        return event.transaction_id, event.log_index  # , event["blockHash"]
+
+    def get_all_balances_for_trustline(self, currency_network_address, a, b):
+        """Get all balances of a trustline in sorted order from the view of a"""
+        balance_update_events = self.get_all_balance_update_events_for_trustline(
+            self.events_proxy, currency_network_address, a
+        )
+
+        def balance(balance_update_event):
+            if balance_update_event.from_ == a and balance_update_event.to == b:
+                return balance_update_event.value
+            elif balance_update_event.from_ == b and balance_update_event.to == a:
+                return -balance_update_event.value
+            else:
+                RuntimeError("Unexpected balance update event")
+
+        return [balance(event) for event in balance_update_events]
+
+    def get_interest_at(self, currency_network_address, balance_update_event):
+        """Returns the applied interests at a given balance update"""
+        from_ = balance_update_event.from_
+        to = balance_update_event.to
+        timestamp = balance_update_event.timestamp
+
+        accrued_interests = self.get_list_of_paid_interests_for_trustline(
+            currency_network_address, from_, to
+        )
+
+        for accrued_interest in accrued_interests:
+            if accrued_interest.timestamp == timestamp:
+                return accrued_interest.value
+        return 0
 
 
 class TransferNotFoundException(Exception):

--- a/src/relay/blockchain/events_informations.py
+++ b/src/relay/blockchain/events_informations.py
@@ -36,6 +36,9 @@ class FeesPaid:
 class TransferInformation:
     path = attr.ib()
     fees_paid = attr.ib()
+    value_sent = attr.ib()
+    value_received = attr.ib()
+    total_fees = attr.ib()
 
 
 class EventsInformationFetcher:
@@ -173,8 +176,17 @@ class EventsInformationFetcher:
         fees_paid = self.get_paid_fees_along_path(
             transfer_path, delta_balances_along_path
         )
+        value_sent = -delta_balances_along_path[0]
+        value_received = delta_balances_along_path[len(delta_balances_along_path) - 1]
+        total_fees = value_sent - value_received
 
-        return TransferInformation(path=transfer_path, fees_paid=fees_paid)
+        return TransferInformation(
+            path=transfer_path,
+            fees_paid=fees_paid,
+            value_sent=value_sent,
+            value_received=value_received,
+            total_fees=total_fees,
+        )
 
     def get_all_transfer_events(self, all_events):
         transfer_events = []

--- a/src/relay/blockchain/events_informations.py
+++ b/src/relay/blockchain/events_informations.py
@@ -35,10 +35,11 @@ class FeesPaid:
 @attr.s
 class TransferInformation:
     path = attr.ib()
-    fees_paid = attr.ib()
+    currency_network = attr.ib()
     value_sent = attr.ib()
     value_received = attr.ib()
     total_fees = attr.ib()
+    fees_paid = attr.ib()
 
 
 class EventsInformationFetcher:
@@ -184,6 +185,7 @@ class EventsInformationFetcher:
 
         return TransferInformation(
             path=transfer_path,
+            currency_network=currency_network_address,
             fees_paid=fees_paid,
             value_sent=value_sent,
             value_received=value_received,

--- a/src/relay/blockchain/proxy.py
+++ b/src/relay/blockchain/proxy.py
@@ -218,7 +218,7 @@ class Proxy(object):
             len(events),
         )
 
-        return sorted_events(self._build_events(events))
+        return self._build_events(events)
 
     def _build_events(self, events: List[Any]):
         current_blocknumber = self._web3.eth.blockNumber

--- a/src/relay/blockchain/proxy.py
+++ b/src/relay/blockchain/proxy.py
@@ -200,7 +200,7 @@ class Proxy(object):
         results = concurrency_utils.joinall(queries, timeout=timeout)
         return sorted_events(list(itertools.chain.from_iterable(results)))
 
-    def get_all_known_abi_transaction_events(self, tx_hash: str, from_block: int = 0):
+    def get_transaction_events(self, tx_hash: str, from_block: int = 0):
         receipt = self._web3.eth.getTransactionReceipt(tx_hash)
         events = []
         for log in receipt["logs"]:
@@ -212,7 +212,7 @@ class Proxy(object):
                 pass
 
         logger.debug(
-            "get_all_known_abi_transaction_events(%s, %s) -> %s rows",
+            "get_transaction_events(%s, %s) -> %s rows",
             tx_hash,
             from_block,
             len(events),

--- a/src/relay/blockchain/proxy.py
+++ b/src/relay/blockchain/proxy.py
@@ -209,7 +209,7 @@ class Proxy(object):
         topic = hexbytes.HexBytes(raw_event_log["topics"][0])
         event_abi = self._topic2event_abi.get(topic)
         if event_abi is None:
-            raise RuntimeError(
+            raise AbiNotFoundException(
                 f"Could not find event abi for log {raw_event_log} on contract {self.address}. "
                 "{topic} not in {self._topic2event_abi.keys()}"
             )
@@ -240,3 +240,7 @@ def sorted_events(events: List[BlockchainEvent]) -> List[BlockchainEvent]:
         return event.blocknumber
 
     return sorted(events, key=key)
+
+
+class AbiNotFoundException(Exception):
+    pass

--- a/src/relay/blockchain/proxy.py
+++ b/src/relay/blockchain/proxy.py
@@ -55,6 +55,8 @@ class LogFilterListener:
 
     def add_proxy(self, proxy: "Proxy"):
         """Add a new proxy to listen for logs"""
+        if proxy.address is None:
+            raise NoAddressError("Tried to listen for logs of proxy with no address")
         self._proxies[proxy.address] = proxy
 
     def start(self):
@@ -130,7 +132,7 @@ class Proxy(object):
     event_builders: Mapping[str, Callable[[Any, int, int], BlockchainEvent]] = {}
     standard_event_types: List[str] = []
 
-    def __init__(self, web3, abi, address: str) -> None:
+    def __init__(self, web3, abi, address: str = None) -> None:
         self._web3 = web3
         self._proxy = web3.eth.contract(abi=abi, address=address)
         self.address = address
@@ -172,6 +174,8 @@ class Proxy(object):
     ) -> List[BlockchainEvent]:
         if event_name not in self.event_builders.keys():
             raise ValueError("Unknown eventname {}".format(event_name))
+        if self.address is None:
+            raise NoAddressError("Tried to get events from proxy with no address")
 
         if filter_ is None:
             filter_ = {}
@@ -196,6 +200,26 @@ class Proxy(object):
         results = concurrency_utils.joinall(queries, timeout=timeout)
         return sorted_events(list(itertools.chain.from_iterable(results)))
 
+    def get_all_known_abi_transaction_events(self, tx_hash: str, from_block: int = 0):
+        receipt = self._web3.eth.getTransactionReceipt(tx_hash)
+        events = []
+        for log in receipt["logs"]:
+            try:
+                abi = self._get_abi_for_log(log)
+                rich_log = get_event_data(abi, log)
+                events.append(rich_log)
+            except AbiNotFoundException:
+                pass
+
+        logger.debug(
+            "get_all_known_abi_transaction_events(%s, %s) -> %s rows",
+            tx_hash,
+            from_block,
+            len(events),
+        )
+
+        return sorted_events(self._build_events(events))
+
     def _build_events(self, events: List[Any]):
         current_blocknumber = self._web3.eth.blockNumber
         return [self._build_event(event, current_blocknumber) for event in events]
@@ -211,7 +235,7 @@ class Proxy(object):
         if event_abi is None:
             raise AbiNotFoundException(
                 f"Could not find event abi for log {raw_event_log} on contract {self.address}. "
-                "{topic} not in {self._topic2event_abi.keys()}"
+                f"{topic} not in {self._topic2event_abi.keys()}"
             )
         return event_abi
 
@@ -243,4 +267,8 @@ def sorted_events(events: List[BlockchainEvent]) -> List[BlockchainEvent]:
 
 
 class AbiNotFoundException(Exception):
+    pass
+
+
+class NoAddressError(Exception):
     pass

--- a/src/relay/ethindex_db.py
+++ b/src/relay/ethindex_db.py
@@ -464,7 +464,7 @@ class EthindexDB:
 
         return events
 
-    def get_all_transaction_events(self, tx_hash: str, from_block: int = 0):
+    def get_all_known_abi_transaction_events(self, tx_hash: str, from_block: int = 0):
 
         query = EventsQuery(
             """blockNumber>=%s
@@ -476,7 +476,7 @@ class EthindexDB:
         events = self._run_events_query(query)
 
         logger.debug(
-            "get_all_transaction_events(%s, %s) -> %s rows",
+            "get_all_known_abi_transaction_events(%s, %s) -> %s rows",
             tx_hash,
             from_block,
             len(events),

--- a/src/relay/ethindex_db.py
+++ b/src/relay/ethindex_db.py
@@ -463,3 +463,23 @@ class EthindexDB:
         )
 
         return events
+
+    def get_all_transaction_events(self, tx_hash: str, from_block: int = 0):
+
+        query = EventsQuery(
+            """blockNumber>=%s
+               AND transactionHash=%s
+            """,
+            (from_block, tx_hash),
+        )
+
+        events = self._run_events_query(query)
+
+        logger.debug(
+            "get_all_transaction_events(%s, %s) -> %s rows",
+            tx_hash,
+            from_block,
+            len(events),
+        )
+
+        return events

--- a/src/relay/ethindex_db.py
+++ b/src/relay/ethindex_db.py
@@ -464,7 +464,7 @@ class EthindexDB:
 
         return events
 
-    def get_all_known_abi_transaction_events(self, tx_hash: str, from_block: int = 0):
+    def get_transaction_events(self, tx_hash: str, from_block: int = 0):
 
         query = EventsQuery(
             """blockNumber>=%s
@@ -476,7 +476,7 @@ class EthindexDB:
         events = self._run_events_query(query)
 
         logger.debug(
-            "get_all_known_abi_transaction_events(%s, %s) -> %s rows",
+            "get_transaction_events(%s, %s) -> %s rows",
             tx_hash,
             from_block,
             len(events),

--- a/src/relay/exchange/orderbook.py
+++ b/src/relay/exchange/orderbook.py
@@ -146,6 +146,9 @@ class OrderBookGreenlet(OrderBook):
     def add_exchange(self, exchange_proxy: ExchangeProxy):
         super().add_exchange(exchange_proxy)
         if self.running:
+            assert (
+                exchange_proxy.address is not None
+            ), "Invalid exchange proxy with no address."
             self._start_listen_on_fill_or_cancel(exchange_proxy.address)
 
     def _start_listen_on_fill_or_cancel(self, exchange_address: str):

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -992,7 +992,3 @@ def create_engine():
             password=os.environ.get("PGPASSWORD", ""),
         )
     )
-
-
-class EthIndexNotUsedException(Exception):
-    pass

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -45,7 +45,7 @@ from .blockchain.events import BlockchainEvent
 from .blockchain.events_informations import EventsInformationFetcher
 from .blockchain.exchange_proxy import ExchangeProxy
 from .blockchain.node import Node
-from .blockchain.proxy import sorted_events
+from .blockchain.proxy import Proxy, sorted_events
 from .blockchain.token_proxy import TokenProxy
 from .blockchain.unw_eth_proxy import UnwEthProxy
 from .events import BalanceEvent, NetworkBalanceEvent
@@ -162,7 +162,7 @@ class TrustlinesRelay:
     def use_eth_index(self) -> bool:
         return os.environ.get("ETHINDEX", "1") == "1"
 
-    def get_event_selector_for_currency_network(self, network_address):
+    def get_event_selector_for_currency_network(self, network_address=None):
         """return either a CurrencyNetworkProxy or a EthindexDB instance
         This is being used from relay.api to query for events.
         """
@@ -175,22 +175,9 @@ class TrustlinesRelay:
                 from_to_types=currency_network_events.from_to_types,
             )
         else:
+            if network_address is None:
+                return Proxy(self._web3, abi=self.contracts["CurrencyNetwork"]["abi"])
             return self.currency_network_proxies[network_address]
-
-    def get_event_selector_without_currency_network(self):
-        """Returns either a CurrencyNetworkProxy or a EthindexDB instance
-        This can be used to query events where address is unknown
-        or via providing the missing address"""
-        if not self.use_eth_index:
-            # pick arbitrarily a proxy in the dict
-            return list(self.currency_network_proxies.values())[0]
-        return ethindex_db.EthindexDB(
-            ethindex_db.connect(""),
-            address=None,
-            standard_event_types=currency_network_events.standard_event_types,
-            event_builders=currency_network_events.event_builders,
-            from_to_types=currency_network_events.from_to_types,
-        )
 
     def get_event_selector_for_token(self, address):
         """return either a proxy or a EthindexDB instance
@@ -249,6 +236,9 @@ class TrustlinesRelay:
     def get_network_info(self, network_address: str) -> NetworkInfo:
         proxy = self.currency_network_proxies[network_address]
         graph = self.currency_network_graphs[network_address]
+        assert (
+            proxy.address is not None
+        ), "Invalid currency network proxy with no address."
         return NetworkInfo(
             address=proxy.address,
             name=proxy.name,
@@ -294,7 +284,7 @@ class TrustlinesRelay:
 
     def get_transfer_information(self, tx_hash):
         fetcher = EventsInformationFetcher(
-            self.get_event_selector_without_currency_network()
+            self.get_event_selector_for_currency_network()
         )
         return fetcher.get_transfer_details(tx_hash)
 

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -44,7 +44,7 @@ from .blockchain.delegate import Delegate, DelegationFees
 from .blockchain.events import BlockchainEvent
 from .blockchain.events_informations import (
     get_list_of_paid_interests_for_trustline_in_between_timestamps,
-    get_tranfer_details,
+    get_transfer_details,
 )
 from .blockchain.exchange_proxy import ExchangeProxy
 from .blockchain.node import Node
@@ -299,7 +299,7 @@ class TrustlinesRelay:
 
     def get_transfer_information(self, tx_hash):
         event_selector = self.get_event_selector_without_currency_network()
-        return get_tranfer_details(event_selector, tx_hash)
+        return get_transfer_details(event_selector, tx_hash)
 
     def deploy_identity(self, factory_address, implementation_address, signature):
         return self.delegate.deploy_identity(

--- a/tests/chain_integration/conftest.py
+++ b/tests/chain_integration/conftest.py
@@ -190,6 +190,24 @@ class CurrencyNetworkProxy(currency_network_proxy.CurrencyNetworkProxy):
         ).transact({"from": from_})
         self._web3.eth.waitForTransactionReceipt(txid)
 
+    def transfer_on_path(self, value, path, max_fee=None, extra_data=b""):
+        if max_fee is None:
+            max_fee = value
+        tx_id = self._proxy.functions.transfer(
+            value, max_fee, path, extra_data
+        ).transact({"from": path[0]})
+        self._web3.eth.waitForTransactionReceipt(tx_id)
+        return tx_id
+
+    def transfer_receiver_pays_on_path(self, value, path, max_fee=None, extra_data=b""):
+        if max_fee is None:
+            max_fee = value
+        tx_id = self._proxy.functions.transferReceiverPays(
+            value, max_fee, path, extra_data
+        ).transact({"from": path[0]})
+        self._web3.eth.waitForTransactionReceipt(tx_id)
+        return tx_id
+
     def transfer_meta_transaction(self, value, max_fee, path, extra_data=b""):
 
         function_call = self._proxy.functions.transfer(value, max_fee, path, extra_data)
@@ -213,6 +231,8 @@ def trustlines(accounts):
         (accounts[1], accounts[2], 200, 250),
         (accounts[2], accounts[3], 300, 350),
         (accounts[3], accounts[4], 400, 450),
+        (accounts[4], accounts[5], 400, 450),
+        (accounts[5], accounts[6], 400, 450),
         (accounts[0], accounts[4], 500, 550),
     ]  # (A, B, clAB, clBA)
 

--- a/tests/chain_integration/test_currency_network.py
+++ b/tests/chain_integration/test_currency_network.py
@@ -67,7 +67,7 @@ def test_account2(currency_network_with_trustlines, accounts):
 
 
 def test_users(currency_network_with_trustlines, accounts):
-    assert currency_network_with_trustlines.fetch_users() == accounts[0:5]
+    assert currency_network_with_trustlines.fetch_users() == accounts[0:7]
 
 
 def test_gen_graph_representation(currency_network_with_trustlines, accounts):

--- a/tests/chain_integration/test_event_information.py
+++ b/tests/chain_integration/test_event_information.py
@@ -1,9 +1,6 @@
 import pytest
 
-from relay.blockchain.events_informations import (
-    get_list_of_paid_interests_for_trustline,
-    get_transfer_details,
-)
+from relay.blockchain.events_informations import EventsInformationFetcher
 
 
 def accrue_interests(currency_network, web3, chain, path, years):
@@ -36,8 +33,10 @@ def test_get_interests_received_for_trustline_positive_balance(
     path = [accounts[0], accounts[1], accounts[2], accounts[3]]
     accrue_interests(currency_network, web3, chain, path, years)
 
-    accrued_interests = get_list_of_paid_interests_for_trustline(
-        currency_network, currency_network, accounts[2], accounts[1]
+    accrued_interests = EventsInformationFetcher(
+        currency_network
+    ).get_list_of_paid_interests_for_trustline(
+        currency_network, accounts[2], accounts[1]
     )
 
     list_of_interests = [
@@ -64,8 +63,10 @@ def test_get_interests_received_for_trustline_negaive_balance(
     path = [accounts[3], accounts[2], accounts[1], accounts[0]]
     accrue_interests(currency_network, web3, chain, path, years)
 
-    accrued_interests = get_list_of_paid_interests_for_trustline(
-        currency_network, currency_network, accounts[1], accounts[2]
+    accrued_interests = EventsInformationFetcher(
+        currency_network
+    ).get_list_of_paid_interests_for_trustline(
+        currency_network, accounts[1], accounts[2]
     )
 
     list_of_interests = [
@@ -92,8 +93,10 @@ def test_get_interests_paid_for_trustline_positive_balance(
     path = [accounts[0], accounts[1], accounts[2], accounts[3]]
     accrue_interests(currency_network, web3, chain, path, years)
 
-    accrued_interests = get_list_of_paid_interests_for_trustline(
-        currency_network, currency_network, accounts[1], accounts[2]
+    accrued_interests = EventsInformationFetcher(
+        currency_network
+    ).get_list_of_paid_interests_for_trustline(
+        currency_network, accounts[1], accounts[2]
     )
 
     list_of_interests = [
@@ -120,8 +123,10 @@ def test_get_interests_paid_for_trustline_negative_balance(
     path = [accounts[3], accounts[2], accounts[1], accounts[0]]
     accrue_interests(currency_network, web3, chain, path, years)
 
-    accrued_interests = get_list_of_paid_interests_for_trustline(
-        currency_network, currency_network, accounts[2], accounts[1]
+    accrued_interests = EventsInformationFetcher(
+        currency_network
+    ).get_list_of_paid_interests_for_trustline(
+        currency_network, accounts[2], accounts[1]
     )
 
     list_of_interests = [
@@ -160,7 +165,9 @@ def test_get_transfer_information_path(
     else:
         assert False, "Invalid fee payer"
 
-    transfer_information = get_transfer_details(network, tx_hash)
+    transfer_information = EventsInformationFetcher(network).get_transfer_details(
+        tx_hash
+    )
     assert transfer_information.path == account_path
 
 
@@ -182,7 +189,9 @@ def test_get_transfer_information_fees_paid(
     else:
         assert False, "Invalid fee payer"
 
-    transfer_information = get_transfer_details(network, tx_hash)
+    transfer_information = EventsInformationFetcher(network).get_transfer_details(
+        tx_hash
+    )
     fees_paid = transfer_information.fees_paid
     for i in range(len(fees_paid)):
         assert fees_paid[i].sender == path[i]

--- a/tests/chain_integration/test_event_information.py
+++ b/tests/chain_integration/test_event_information.py
@@ -169,7 +169,7 @@ def test_get_transfer_information_path(
     transfer_information = EventsInformationFetcher(network).get_transfer_details(
         tx_hash
     )
-    assert transfer_information.payment_path.path == account_path
+    assert transfer_information.path == account_path
 
 
 @pytest.mark.parametrize("fee_payer", [FeePayer.SENDER, FeePayer.RECEIVER])
@@ -195,7 +195,7 @@ def test_get_transfer_information_values(
         tx_hash
     )
     assert transfer_information.fees_paid == [1, 1, 1, 1, 1]
-    assert transfer_information.payment_path.value == value
-    assert transfer_information.payment_path.fee == number_of_mediators
-    assert transfer_information.payment_path.fee_payer == fee_payer
+    assert transfer_information.value == value
+    assert transfer_information.total_fees == number_of_mediators
+    assert transfer_information.fee_payer == fee_payer
     assert transfer_information.currency_network == network.address


### PR DESCRIPTION
It is largely inspired by the contracts test for events.

I took as starting point a tx_hash and fail if there is more than one TL transfer within the given tx. If we have a better means of identifying events later, this could be changed.

I am using a proxy to a currency network without an address to get all CN events from a tx_hash, which might be dirty.

I made a class EventsInformationFetcher so that we do not have to pass around `events_proxy` between every function. I think it will also help in the future if we want to optimize the number of request we make to the event_proxy (e.g. by decoupling fetching of event and processing of info).