### PR TITLE
Only get transfer and balance update events from tx for transfer details

### DIFF
--- a/src/relay/blockchain/events_informations.py
+++ b/src/relay/blockchain/events_informations.py
@@ -74,7 +74,9 @@ class EventsInformationFetcher:
 
     def get_transfer_details(self, tx_hash):
 
-        all_events_of_tx = self.events_proxy.get_transaction_events(tx_hash)
+        all_events_of_tx = self.events_proxy.get_transaction_events(
+            tx_hash, event_types=(TransferEventType, BalanceUpdateEventType)
+        )
         transfer_events_in_tx = filter_events(all_events_of_tx, TransferEventType)
         if len(transfer_events_in_tx) == 0:
             raise TransferNotFoundException(tx_hash)

--- a/src/relay/blockchain/proxy.py
+++ b/src/relay/blockchain/proxy.py
@@ -5,7 +5,7 @@ import math
 import socket
 import time
 from collections import defaultdict
-from typing import Any, Callable, Dict, List, Mapping, Optional, Set
+from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple
 
 import eth_utils
 import gevent
@@ -200,14 +200,17 @@ class Proxy(object):
         results = concurrency_utils.joinall(queries, timeout=timeout)
         return sorted_events(list(itertools.chain.from_iterable(results)))
 
-    def get_transaction_events(self, tx_hash: str, from_block: int = 0):
+    def get_transaction_events(
+        self, tx_hash: str, from_block: int = 0, event_types: Tuple = None
+    ):
         receipt = self._web3.eth.getTransactionReceipt(tx_hash)
         events = []
         for log in receipt["logs"]:
             try:
                 abi = self._get_abi_for_log(log)
                 rich_log = get_event_data(abi, log)
-                events.append(rich_log)
+                if event_types is None or rich_log["event"] in event_types:
+                    events.append(rich_log)
             except AbiNotFoundException:
                 pass
 

--- a/src/relay/ethindex_db.py
+++ b/src/relay/ethindex_db.py
@@ -2,7 +2,7 @@
 
 import collections
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import psycopg2
 import psycopg2.extras
@@ -464,21 +464,26 @@ class EthindexDB:
 
         return events
 
-    def get_transaction_events(self, tx_hash: str, from_block: int = 0):
+    def get_transaction_events(
+        self, tx_hash: str, from_block: int = 0, event_types: Tuple = None
+    ):
+        event_types = self._get_standard_event_types(event_types)
 
         query = EventsQuery(
             """blockNumber>=%s
                AND transactionHash=%s
+               AND eventName in %s
             """,
-            (from_block, tx_hash),
+            (from_block, tx_hash, event_types),
         )
 
         events = self._run_events_query(query)
 
         logger.debug(
-            "get_transaction_events(%s, %s) -> %s rows",
+            "get_transaction_events(%s, %s, %s) -> %s rows",
             tx_hash,
             from_block,
+            event_types,
             len(events),
         )
 


### PR DESCRIPTION
This fixes a bug where the relay would not be able to get transfer
details for meta-transactions since they have DebtUpdate events in the
eth-index db and these have no corresponding event builders.

(I guess mypy helped me this time)