### PR TITLE
Add mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,9 @@ repos:
     - id: trailing-whitespace
     - id: no-commit-to-branch
       args: [--branch, develop, --branch, master]
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.720
+    hooks:
+    -   id: mypy
+        args: [--ignore-missing-imports]


### PR DESCRIPTION
I could not find an issue with a reason why we did not do that, but maybe there is one.