### PR TITLE
Deprecate transactionId for transactionHash

### DIFF
--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -99,7 +99,10 @@ class MessageEventSchema(EventSchema):
 class BlockchainEventSchema(EventSchema):
     blockNumber = fields.Integer(attribute="blocknumber")
     type = fields.Str(default="event")
-    transactionId = HexBytes(attribute="transaction_id")
+    transactionId = HexBytes(
+        attribute="transaction_hash", dump_only=True
+    )  # TODO: Deprecated, remove in future release
+    transactionHash = HexBytes(attribute="transaction_hash")
     status = fields.Str()
     blockHash = HexBytes(attribute="block_hash")
     logIndex = fields.Int(attribute="log_index")

--- a/src/relay/blockchain/events.py
+++ b/src/relay/blockchain/events.py
@@ -19,7 +19,6 @@ class BlockchainEvent(Event):
         else:
             self.block_hash = None
         self.transaction_hash = _field_to_hexbytes(web3_event.get("transactionHash"))
-        self.transaction_id = self.transaction_hash
         self.type = web3_event.get("event")
         self.log_index = web3_event.get("logIndex")
 

--- a/src/relay/blockchain/events_informations.py
+++ b/src/relay/blockchain/events_informations.py
@@ -390,7 +390,7 @@ def get_balance_from_update_event_viewed_from_a(balance_update_event, a):
 
 
 def event_id(event):
-    return event.transaction_id, event.log_index
+    return event.block_hash, event.log_index
 
 
 class TransferNotFoundException(Exception):

--- a/src/relay/pushservice/pushservice.py
+++ b/src/relay/pushservice/pushservice.py
@@ -41,12 +41,12 @@ def dedup_event_id(client_token, event: Event):
     """generate an event id used for deduplicating push notifications
 
     returns None when a message for the event should be sent anyway, otherwise it
-    returns a tuple of the client_token, the event type and the transaction_id.
+    returns a tuple of the client_token, the event type and the transaction_hash.
     This tuple should be used to deduplicate messages, i.e. we should not send messages twice for
     the same tuple.
     """
     if isinstance(event, BlockchainEvent):
-        return client_token, event.type, event.transaction_id
+        return client_token, event.type, event.transaction_hash
     else:
         return None
 


### PR DESCRIPTION
Add transactionHash to rest endpoints. transactionId is kept for
backwardscompatibilty but will be removed in the future.