### PR TITLE
Fix validation of transfer endpoint

### DIFF
--- a/src/relay/api/fields.py
+++ b/src/relay/api/fields.py
@@ -1,3 +1,5 @@
+import re
+
 import hexbytes
 from eth_utils import is_address, to_checksum_address
 from marshmallow import fields
@@ -19,6 +21,24 @@ class Address(fields.Field):
             )
 
         return to_checksum_address(value)
+
+
+class Hash(fields.String):
+    def _serialize(self, value, attr, obj, **kwargs):
+        if isinstance(value, str) or not re.match(r"0x[0-9a-fA-F]{64}", value):
+            raise ValidationError(
+                f"Could not parse attribute {attr}: Invalid hash {value}"
+            )
+
+        return value
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if not isinstance(value, str) or not re.match(r"0x[0-9a-fA-F]{64}", value):
+            raise ValidationError(
+                f"Could not parse attribute {attr}: Invalid hash {value}"
+            )
+
+        return value
 
 
 class BigInteger(fields.Field):

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -526,7 +526,7 @@ class TransferInformation(Resource):
         block_hash = args["blockHash"]
         log_index = args["logIndex"]
 
-        if transaction_hash:
+        if transaction_hash is not None:
             try:
                 return self.trustlines.get_transfer_information_for_tx_hash(
                     transaction_hash
@@ -536,7 +536,7 @@ class TransferInformation(Resource):
                     404,
                     f"No transfer found in transaction with transaction hash: {e.tx_hash}",
                 )
-        elif block_hash and log_index:
+        elif block_hash is not None and log_index is not None:
             try:
                 return self.trustlines.get_transfer_information_from_event_id(
                     block_hash, log_index

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -1,5 +1,6 @@
 import hexbytes
 from marshmallow import Schema, ValidationError, fields, post_load, validates_schema
+from marshmallow.validate import Range
 from marshmallow_oneofschema import OneOfSchema
 from tldeploy import identity
 from tldeploy.identity import MetaTransaction
@@ -14,6 +15,7 @@ from .fields import (
     Address,
     BigInteger,
     FeePayerField,
+    Hash,
     HexBytes,
     HexEncodedBytes,
     MetaTransactionStatusField,
@@ -293,23 +295,25 @@ class TransferIdentifierSchema(Schema):
         transaction_hash = data["transactionHash"]
         block_hash = data["blockHash"]
         log_index = data["logIndex"]
-        if transaction_hash and (block_hash or log_index):
+        if transaction_hash is not None and (
+            block_hash is not None or log_index is not None
+        ):
             raise ValidationError(
                 f"Cannot get transfer information using transaction hash and log index or block hash."
             )
-        elif block_hash and not log_index:
+        elif block_hash is not None and log_index is None:
             raise ValidationError(
                 f"Cannot get transfer information using block hash if log index not provided."
             )
-        elif log_index and not block_hash:
+        elif log_index is not None and block_hash is None:
             raise ValidationError(
                 f"Cannot get transfer information using log index if block hash not provided."
             )
-        elif not log_index and not block_hash and not transaction_hash:
+        elif log_index is None and block_hash is None and transaction_hash is None:
             raise ValidationError(
                 "Either transaction hash or block hash and log index need to be provided."
             )
 
-    transactionHash = fields.Str(required=False, missing=None)
-    blockHash = fields.Str(required=False, missing=None)
-    logIndex = fields.Int(required=False, missing=None)
+    transactionHash = Hash(required=False, missing=None)
+    blockHash = Hash(required=False, missing=None)
+    logIndex = fields.Int(required=False, missing=None, validate=Range(min=0))


### PR DESCRIPTION
Fix the validation so that it can also handle 0 as logIndex. Before this
was not possible, because 0 will be evaluated as False. The correct way
is to check not None instead.
Also check now that logIndex is a positive number and hash has the
correct format.