### PR TITLE
Refactor ethindex

### DIFF
--- a/src/relay/api/exchange/resources.py
+++ b/src/relay/api/exchange/resources.py
@@ -214,7 +214,7 @@ class UserEventsExchange(Resource):
             )
         except TimeoutException:
             logger.warning(
-                "User exchange events: event_name=%s user_address=%s from_block=%s. could not get events in time",
+                "User exchange events: event_type=%s user_address=%s from_block=%s. could not get events in time",
                 type,
                 user_address,
                 from_block,
@@ -247,7 +247,7 @@ class UserEventsAllExchanges(Resource):
         except TimeoutException:
             logger.warning(
                 """User exchange events from all exchanges:
-                   event_name=%s user_address=%s from_block=%s. could not get events in time""",
+                   event_type=%s user_address=%s from_block=%s. could not get events in time""",
                 type,
                 user_address,
                 from_block,
@@ -280,7 +280,7 @@ class EventsExchange(Resource):
             )
         except TimeoutException:
             logger.warning(
-                "Exchange events: event_name=%s from_block=%s. could not get events in time",
+                "Exchange events: event_type=%s from_block=%s. could not get events in time",
                 type,
                 from_block,
             )

--- a/src/relay/api/exchange/resources.py
+++ b/src/relay/api/exchange/resources.py
@@ -208,18 +208,10 @@ class UserEventsExchange(Resource):
         abort_if_unknown_exchange(self.trustlines, exchange_address)
         from_block = args["fromBlock"]
         type = args["type"]
-        try:
-            return self.trustlines.get_user_exchange_events(
-                exchange_address, user_address, type=type, from_block=from_block
-            )
-        except TimeoutException:
-            logger.warning(
-                "User exchange events: event_type=%s user_address=%s from_block=%s. could not get events in time",
-                type,
-                user_address,
-                from_block,
-            )
-            abort(504, TIMEOUT_MESSAGE)
+
+        return self.trustlines.get_user_exchange_events(
+            exchange_address, user_address, type=type, from_block=from_block
+        )
 
 
 class UserEventsAllExchanges(Resource):
@@ -274,14 +266,7 @@ class EventsExchange(Resource):
         abort_if_unknown_exchange(self.trustlines, exchange_address)
         from_block = args["fromBlock"]
         type = args["type"]
-        try:
-            return self.trustlines.get_exchange_events(
-                exchange_address, type=type, from_block=from_block
-            )
-        except TimeoutException:
-            logger.warning(
-                "Exchange events: event_type=%s from_block=%s. could not get events in time",
-                type,
-                from_block,
-            )
-            abort(504, TIMEOUT_MESSAGE)
+
+        return self.trustlines.get_exchange_events(
+            exchange_address, type=type, from_block=from_block
+        )

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -341,7 +341,7 @@ class UserEventsNetwork(Resource):
             )
         except TimeoutException:
             logger.warning(
-                "User network events: event_name=%s user_address=%s from_block=%s. could not get events in time",
+                "User network events: event_type=%s user_address=%s from_block=%s. could not get events in time",
                 type,
                 user_address,
                 from_block,
@@ -380,7 +380,7 @@ class TrustlineEvents(Resource):
             )
         except TimeoutException:
             logger.warning(
-                "Trustline events: event_name=%s user_address=%s "
+                "Trustline events: event_type=%s user_address=%s "
                 "counter_party_address=%s, from_block=%s. could not get events in time",
                 type,
                 user_address,
@@ -419,7 +419,7 @@ class UserEvents(Resource):
             )
         except TimeoutException:
             logger.warning(
-                "User events: event_name=%s user_address=%s from_block=%s. could not get events in time",
+                "User events: event_type=%s user_address=%s from_block=%s. could not get events in time",
                 type,
                 user_address,
                 from_block,
@@ -452,7 +452,7 @@ class EventsNetwork(Resource):
             )
         except TimeoutException:
             logger.warning(
-                "Network events: event_name=%s from_block=%s. could not get events in time",
+                "Network events: event_type=%s from_block=%s. could not get events in time",
                 type,
                 from_block,
             )

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -33,7 +33,6 @@ from relay.blockchain.events_informations import (
     TransferNotFoundException,
 )
 from relay.blockchain.unw_eth_events import all_event_types as all_unw_eth_event_types
-from relay.concurrency_utils import TimeoutException
 from relay.network_graph.payment_path import FeePayer, PaymentPath
 from relay.relay import TrustlinesRelay
 from relay.utils import get_version, sha3
@@ -335,18 +334,10 @@ class UserEventsNetwork(Resource):
         abort_if_unknown_network(self.trustlines, network_address)
         from_block = args["fromBlock"]
         type = args["type"]
-        try:
-            return self.trustlines.get_user_network_events(
-                network_address, user_address, type=type, from_block=from_block
-            )
-        except TimeoutException:
-            logger.warning(
-                "User network events: event_type=%s user_address=%s from_block=%s. could not get events in time",
-                type,
-                user_address,
-                from_block,
-            )
-            abort(504, TIMEOUT_MESSAGE)
+
+        return self.trustlines.get_user_network_events(
+            network_address, user_address, type=type, from_block=from_block
+        )
 
 
 class TrustlineEvents(Resource):
@@ -370,24 +361,14 @@ class TrustlineEvents(Resource):
         abort_if_unknown_network(self.trustlines, network_address)
         from_block = args["fromBlock"]
         type = args["type"]
-        try:
-            return self.trustlines.get_trustline_events(
-                network_address,
-                user_address,
-                counter_party_address,
-                type=type,
-                from_block=from_block,
-            )
-        except TimeoutException:
-            logger.warning(
-                "Trustline events: event_type=%s user_address=%s "
-                "counter_party_address=%s, from_block=%s. could not get events in time",
-                type,
-                user_address,
-                counter_party_address,
-                from_block,
-            )
-            abort(504, TIMEOUT_MESSAGE)
+
+        return self.trustlines.get_trustline_events(
+            network_address,
+            user_address,
+            counter_party_address,
+            type=type,
+            from_block=from_block,
+        )
 
 
 class UserEvents(Resource):
@@ -410,21 +391,13 @@ class UserEvents(Resource):
     def get(self, args, user_address: str):
         type = args["type"]
         from_block = args["fromBlock"]
-        try:
-            return self.trustlines.get_user_events(
-                user_address,
-                type=type,
-                from_block=from_block,
-                timeout=self.trustlines.event_query_timeout,
-            )
-        except TimeoutException:
-            logger.warning(
-                "User events: event_type=%s user_address=%s from_block=%s. could not get events in time",
-                type,
-                user_address,
-                from_block,
-            )
-            abort(504, TIMEOUT_MESSAGE)
+
+        return self.trustlines.get_user_events(
+            user_address,
+            type=type,
+            from_block=from_block,
+            timeout=self.trustlines.event_query_timeout,
+        )
 
 
 class EventsNetwork(Resource):
@@ -446,17 +419,10 @@ class EventsNetwork(Resource):
         abort_if_unknown_network(self.trustlines, network_address)
         from_block = args["fromBlock"]
         type = args["type"]
-        try:
-            return self.trustlines.get_network_events(
-                network_address, type=type, from_block=from_block
-            )
-        except TimeoutException:
-            logger.warning(
-                "Network events: event_type=%s from_block=%s. could not get events in time",
-                type,
-                from_block,
-            )
-            abort(504, TIMEOUT_MESSAGE)
+
+        return self.trustlines.get_network_events(
+            network_address, type=type, from_block=from_block
+        )
 
 
 class UserAccruedInterestList(Resource):

--- a/src/relay/blockchain/events_informations.py
+++ b/src/relay/blockchain/events_informations.py
@@ -14,7 +14,7 @@ from relay.blockchain.currency_network_events import (
     TrustlineUpdateEventType,
 )
 from relay.blockchain.events import BlockchainEvent
-from relay.ethindex_db import EthindexDB
+from relay.ethindex_db import CurrencyNetworkEthindexDB
 from relay.network_graph.interests import calculate_interests
 from relay.network_graph.payment_path import FeePayer
 
@@ -42,7 +42,7 @@ class TransferInformation:
 
 
 class EventsInformationFetcher:
-    def __init__(self, events_proxy: EthindexDB):
+    def __init__(self, events_proxy: CurrencyNetworkEthindexDB):
         self.events_proxy = events_proxy
 
     def get_list_of_paid_interests_for_trustline(

--- a/src/relay/ethindex_db.py
+++ b/src/relay/ethindex_db.py
@@ -88,16 +88,8 @@ order_by_default_sort_order = """ ORDER BY blocknumber, transactionIndex, logInd
 
 
 class EthindexDB:
-    """EthIndexDB provides a partly compatible interface for the
-       relay.blockchain.currency_network_proxy.CurrencyNetworkProxy,
-       relay.blockchain.token_proxy.TokenProxy and
-       relay.blockchain.unw_eth_proxy.UnwEthProxy classes
-
-    We implement just enough to make it possible to use this as a drop-in
-    replacement for relay.api.resources, that is, just the event reading.
-
-    Since the proxy classes operates on one network address only,
-    we allow to pass a default address in.
+    """EthIndexDB provides an interface for ethindex database
+    it used to access events from the database.
     """
 
     def __init__(
@@ -163,48 +155,6 @@ class EthindexDB:
                 rows = cur.fetchall()
                 return self._build_events(rows)
 
-    def get_network_events(
-        self,
-        event_name: str,
-        user_address: str = None,
-        from_block: int = 0,
-        timeout: float = None,
-    ) -> List[BlockchainEvent]:
-        """Function for compatibility with relay.blockchain.CurrencyNetworkProxy.
-        Will be removed after a refactoring
-        """
-        return self.get_user_events(event_name, user_address, from_block, timeout)
-
-    def get_unw_eth_events(
-        self,
-        event_name: str,
-        user_address: str = None,
-        from_block: int = 0,
-        timeout: float = None,
-    ) -> List[BlockchainEvent]:
-        """Function for compatibility with relay.blockchain.UnwEthProxy. Will be removed after a refactoring"""
-        return self.get_user_events(event_name, user_address, from_block, timeout)
-
-    def get_token_events(
-        self,
-        event_name: str,
-        user_address: str = None,
-        from_block: int = 0,
-        timeout: float = None,
-    ) -> List[BlockchainEvent]:
-        """Function for compatibility with relay.blockchain.TokenProxy. Will be removed after a refactoring"""
-        return self.get_user_events(event_name, user_address, from_block, timeout)
-
-    def get_exchange_events(
-        self,
-        event_name: str,
-        user_address: str = None,
-        from_block: int = 0,
-        timeout: float = None,
-    ) -> List[BlockchainEvent]:
-        """Function for compatibility with relay.blockchain.ExchangeProxy. Will be removed after a refactoring"""
-        return self.get_user_events(event_name, user_address, from_block, timeout)
-
     def get_user_events(
         self,
         event_name: str,
@@ -251,91 +201,6 @@ class EthindexDB:
             else:
                 raise ValueError("Expected a TLNetworkEvent")
         return events
-
-    def get_trustline_events(
-        self,
-        contract_address: str,
-        user_address: str,
-        counterparty_address: str,
-        event_types: Iterable[str] = None,
-        from_block: int = 0,
-        timeout: float = None,
-    ):
-        event_types = self._get_standard_event_types(event_types)
-
-        all_event_fieldname_combination = set()
-        for from_, to in self.from_to_types.values():
-            all_event_fieldname_combination.add((from_, to))
-            all_event_fieldname_combination.add((to, from_))
-
-        member_filter_block = " OR ".join(
-            f"(args->>'{field_a}'=%s AND args->>'{field_b}'=%s)"
-            for field_a, field_b in all_event_fieldname_combination
-        )
-
-        args: List[Any] = [from_block, tuple(event_types), contract_address]
-        for _ in all_event_fieldname_combination:
-            args.extend((user_address, counterparty_address))
-
-        query = EventsQuery(
-            f"""blockNumber>=%s
-               AND eventName in %s
-               AND address=%s
-               AND ({member_filter_block})
-            """,
-            args,
-        )
-
-        events = self._run_events_query(query)
-
-        logger.debug(
-            "get_trustline_events(%s, %s, %s, %s, %s, %s) -> %s rows",
-            contract_address,
-            user_address,
-            counterparty_address,
-            event_types,
-            from_block,
-            timeout,
-            len(events),
-        )
-
-        for event in events:
-            if isinstance(event, TLNetworkEvent):
-                event.user = user_address
-            else:
-                raise ValueError("Expected a TLNetworkEvent")
-        return events
-
-    def get_all_unw_eth_events(
-        self, user_address: str = None, from_block: int = 0, timeout: float = None
-    ) -> List[BlockchainEvent]:
-        return self.get_all_contract_events(
-            unw_eth_events.standard_event_types, user_address, from_block, timeout
-        )
-
-    def get_all_token_events(
-        self, user_address: str = None, from_block: int = 0, timeout: float = None
-    ) -> List[BlockchainEvent]:
-        return self.get_all_contract_events(
-            token_events.standard_event_types, user_address, from_block, timeout
-        )
-
-    def get_all_network_events(
-        self, user_address: str = None, from_block: int = 0, timeout: float = None
-    ) -> List[BlockchainEvent]:
-        return self.get_all_contract_events(
-            currency_network_events.standard_event_types,
-            user_address,
-            from_block,
-            timeout,
-        )
-
-    def get_all_exchange_events(
-        self, user_address: str = None, from_block: int = 0, timeout: float = None
-    ) -> List[BlockchainEvent]:
-        return self.get_all_contract_events(
-            exchange_events.standard_event_types, user_address, from_block, timeout
-        )
 
     def get_all_contract_events(
         self,
@@ -504,3 +369,132 @@ class EthindexDB:
         )
 
         return transaction_events
+
+
+class CurrencyNetworkEthindexDB(EthindexDB):
+    def get_network_events(
+        self,
+        event_name: str,
+        user_address: str = None,
+        from_block: int = 0,
+        timeout: float = None,
+    ) -> List[BlockchainEvent]:
+        return self.get_user_events(event_name, user_address, from_block, timeout)
+
+    def get_all_network_events(
+        self, user_address: str = None, from_block: int = 0, timeout: float = None
+    ) -> List[BlockchainEvent]:
+        return self.get_all_contract_events(
+            currency_network_events.standard_event_types,
+            user_address,
+            from_block,
+            timeout,
+        )
+
+    def get_trustline_events(
+        self,
+        contract_address: str,
+        user_address: str,
+        counterparty_address: str,
+        event_types: Iterable[str] = None,
+        from_block: int = 0,
+        timeout: float = None,
+    ):
+        event_types = self._get_standard_event_types(event_types)
+
+        all_event_fieldname_combination = set()
+        for from_, to in self.from_to_types.values():
+            all_event_fieldname_combination.add((from_, to))
+            all_event_fieldname_combination.add((to, from_))
+
+        member_filter_block = " OR ".join(
+            f"(args->>'{field_a}'=%s AND args->>'{field_b}'=%s)"
+            for field_a, field_b in all_event_fieldname_combination
+        )
+
+        args: List[Any] = [from_block, tuple(event_types), contract_address]
+        for _ in all_event_fieldname_combination:
+            args.extend((user_address, counterparty_address))
+
+        query = EventsQuery(
+            f"""blockNumber>=%s
+               AND eventName in %s
+               AND address=%s
+               AND ({member_filter_block})
+            """,
+            args,
+        )
+
+        events = self._run_events_query(query)
+
+        logger.debug(
+            "get_trustline_events(%s, %s, %s, %s, %s, %s) -> %s rows",
+            contract_address,
+            user_address,
+            counterparty_address,
+            event_types,
+            from_block,
+            timeout,
+            len(events),
+        )
+
+        for event in events:
+            if isinstance(event, TLNetworkEvent):
+                event.user = user_address
+            else:
+                raise ValueError("Expected a TLNetworkEvent")
+        return events
+
+
+class UnwEthEthindexDb(EthindexDB):
+    def get_unw_eth_events(
+        self,
+        event_name: str,
+        user_address: str = None,
+        from_block: int = 0,
+        timeout: float = None,
+    ) -> List[BlockchainEvent]:
+        return self.get_user_events(event_name, user_address, from_block, timeout)
+
+    def get_all_unw_eth_events(
+        self, user_address: str = None, from_block: int = 0, timeout: float = None
+    ) -> List[BlockchainEvent]:
+        return self.get_all_contract_events(
+            unw_eth_events.standard_event_types, user_address, from_block, timeout
+        )
+
+
+class TokenEthindexDB(EthindexDB):
+    def get_token_events(
+        self,
+        event_name: str,
+        user_address: str = None,
+        from_block: int = 0,
+        timeout: float = None,
+    ) -> List[BlockchainEvent]:
+        return self.get_user_events(event_name, user_address, from_block, timeout)
+
+    def get_all_token_events(
+        self, user_address: str = None, from_block: int = 0, timeout: float = None
+    ) -> List[BlockchainEvent]:
+        return self.get_all_contract_events(
+            token_events.standard_event_types, user_address, from_block, timeout
+        )
+
+
+class ExchangeEthindexDB(EthindexDB):
+    def get_exchange_events(
+        self,
+        event_name: str,
+        user_address: str = None,
+        from_block: int = 0,
+        timeout: float = None,
+    ) -> List[BlockchainEvent]:
+        return self.get_user_events(event_name, user_address, from_block, timeout)
+
+    def get_all_exchange_events(
+        self, user_address: str = None, from_block: int = 0, timeout: float = None
+    ) -> List[BlockchainEvent]:
+        return self.get_all_contract_events(
+            exchange_events.standard_event_types, user_address, from_block, timeout
+        )

--- a/src/relay/ethindex_db.py
+++ b/src/relay/ethindex_db.py
@@ -152,7 +152,7 @@ class EthindexDB:
 
     def get_user_events(
         self,
-        event_name: str,
+        event_type: str,
         user_address: str = None,
         from_block: int = 0,
         timeout: float = None,
@@ -161,7 +161,7 @@ class EthindexDB:
         contract_address = self._get_addr(contract_address)
         if user_address is None:
             return self.get_events(
-                event_name,
+                event_type,
                 from_block=from_block,
                 timeout=timeout,
                 contract_address=contract_address,
@@ -172,17 +172,17 @@ class EthindexDB:
                AND address=%s
                AND (args->>'{_from}'=%s or args->>'{_to}'=%s)
             """.format(
-                _from=self.from_to_types[event_name][0],
-                _to=self.from_to_types[event_name][1],
+                _from=self.from_to_types[event_type][0],
+                _to=self.from_to_types[event_type][1],
             ),
-            (from_block, event_name, contract_address, user_address, user_address),
+            (from_block, event_type, contract_address, user_address, user_address),
         )
 
         events = self._run_events_query(query)
 
         logger.debug(
             "get_user_events(%s, %s, %s, %s, %s) -> %s rows",
-            event_name,
+            event_type,
             user_address,
             from_block,
             timeout,
@@ -259,7 +259,7 @@ class EthindexDB:
 
     def get_events(
         self,
-        event_name,
+        event_type,
         from_block=0,
         timeout: float = None,
         contract_address: str = None,
@@ -269,13 +269,13 @@ class EthindexDB:
             """blockNumber>=%s
                AND eventName=%s
                AND address=%s""",
-            (from_block, event_name, contract_address),
+            (from_block, event_type, contract_address),
         )
         events = self._run_events_query(query)
 
         logger.debug(
             "get_events(%s, %s, %s, %s) -> %s rows",
-            event_name,
+            event_type,
             from_block,
             timeout,
             contract_address,
@@ -369,12 +369,12 @@ class EthindexDB:
 class CurrencyNetworkEthindexDB(EthindexDB):
     def get_network_events(
         self,
-        event_name: str,
+        event_type: str,
         user_address: str = None,
         from_block: int = 0,
         timeout: float = None,
     ) -> List[BlockchainEvent]:
-        return self.get_user_events(event_name, user_address, from_block, timeout)
+        return self.get_user_events(event_type, user_address, from_block, timeout)
 
     def get_all_network_events(
         self, user_address: str = None, from_block: int = 0, timeout: float = None

--- a/src/relay/ethindex_db.py
+++ b/src/relay/ethindex_db.py
@@ -7,12 +7,7 @@ from typing import Any, Dict, Iterable, List, Optional
 import psycopg2
 import psycopg2.extras
 
-from relay.blockchain import (
-    currency_network_events,
-    exchange_events,
-    token_events,
-    unw_eth_events,
-)
+from relay.blockchain import currency_network_events
 from relay.blockchain.events import BlockchainEvent, TLNetworkEvent
 
 # proxy.get_all_events just asks for these network events. so we need the list
@@ -444,57 +439,3 @@ class CurrencyNetworkEthindexDB(EthindexDB):
             else:
                 raise ValueError("Expected a TLNetworkEvent")
         return events
-
-
-class UnwEthEthindexDb(EthindexDB):
-    def get_unw_eth_events(
-        self,
-        event_name: str,
-        user_address: str = None,
-        from_block: int = 0,
-        timeout: float = None,
-    ) -> List[BlockchainEvent]:
-        return self.get_user_events(event_name, user_address, from_block, timeout)
-
-    def get_all_unw_eth_events(
-        self, user_address: str = None, from_block: int = 0, timeout: float = None
-    ) -> List[BlockchainEvent]:
-        return self.get_all_contract_events(
-            unw_eth_events.standard_event_types, user_address, from_block, timeout
-        )
-
-
-class TokenEthindexDB(EthindexDB):
-    def get_token_events(
-        self,
-        event_name: str,
-        user_address: str = None,
-        from_block: int = 0,
-        timeout: float = None,
-    ) -> List[BlockchainEvent]:
-        return self.get_user_events(event_name, user_address, from_block, timeout)
-
-    def get_all_token_events(
-        self, user_address: str = None, from_block: int = 0, timeout: float = None
-    ) -> List[BlockchainEvent]:
-        return self.get_all_contract_events(
-            token_events.standard_event_types, user_address, from_block, timeout
-        )
-
-
-class ExchangeEthindexDB(EthindexDB):
-    def get_exchange_events(
-        self,
-        event_name: str,
-        user_address: str = None,
-        from_block: int = 0,
-        timeout: float = None,
-    ) -> List[BlockchainEvent]:
-        return self.get_user_events(event_name, user_address, from_block, timeout)
-
-    def get_all_exchange_events(
-        self, user_address: str = None, from_block: int = 0, timeout: float = None
-    ) -> List[BlockchainEvent]:
-        return self.get_all_contract_events(
-            exchange_events.standard_event_types, user_address, from_block, timeout
-        )

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -160,11 +160,11 @@ class TrustlinesRelay:
 
     def get_ethindex_db_for_currency_network(
         self, network_address: Optional[str] = None
-    ) -> ethindex_db.EthindexDB:
+    ) -> ethindex_db.CurrencyNetworkEthindexDB:
         """return an EthindexDB instance.
         This is being used from relay.api to query for events.
         """
-        return ethindex_db.EthindexDB(
+        return ethindex_db.CurrencyNetworkEthindexDB(
             ethindex_db.connect(""),
             address=network_address,
             standard_event_types=currency_network_events.standard_event_types,
@@ -176,7 +176,7 @@ class TrustlinesRelay:
         """return an EthindexDB instance
         This is being used from relay.api to query for events.
         """
-        return ethindex_db.EthindexDB(
+        return ethindex_db.TokenEthindexDB(
             ethindex_db.connect(""),
             address=address,
             standard_event_types=token_events.standard_event_types,
@@ -188,7 +188,7 @@ class TrustlinesRelay:
         """return an EthindexDB instance
         This is being used from relay.api to query for events.
         """
-        return ethindex_db.EthindexDB(
+        return ethindex_db.UnwEthEthindexDb(
             ethindex_db.connect(""),
             address=address,
             standard_event_types=unw_eth_events.standard_event_types,
@@ -200,7 +200,7 @@ class TrustlinesRelay:
         """return an EthindexDB instance
         This is being used from relay.api to query for events.
         """
-        return ethindex_db.EthindexDB(
+        return ethindex_db.ExchangeEthindexDB(
             ethindex_db.connect(""),
             address=address,
             standard_event_types=exchange_events.standard_event_types,
@@ -513,7 +513,7 @@ class TrustlinesRelay:
         else:
             event_types = [type]
 
-        ethindex = ethindex_db.EthindexDB(
+        ethindex = ethindex_db.CurrencyNetworkEthindexDB(
             ethindex_db.connect(""),
             address=network_address,
             standard_event_types=currency_network_events.trustline_event_types,

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -176,7 +176,7 @@ class TrustlinesRelay:
         """return an EthindexDB instance
         This is being used from relay.api to query for events.
         """
-        return ethindex_db.TokenEthindexDB(
+        return ethindex_db.EthindexDB(
             ethindex_db.connect(""),
             address=address,
             standard_event_types=token_events.standard_event_types,
@@ -188,7 +188,7 @@ class TrustlinesRelay:
         """return an EthindexDB instance
         This is being used from relay.api to query for events.
         """
-        return ethindex_db.UnwEthEthindexDb(
+        return ethindex_db.EthindexDB(
             ethindex_db.connect(""),
             address=address,
             standard_event_types=unw_eth_events.standard_event_types,
@@ -200,7 +200,7 @@ class TrustlinesRelay:
         """return an EthindexDB instance
         This is being used from relay.api to query for events.
         """
-        return ethindex_db.ExchangeEthindexDB(
+        return ethindex_db.EthindexDB(
             ethindex_db.connect(""),
             address=address,
             standard_event_types=exchange_events.standard_event_types,
@@ -618,7 +618,7 @@ class TrustlinesRelay:
             if type is not None and type in ethindex_db.event_types:
                 queries.append(
                     functools.partial(
-                        ethindex_db.get_unw_eth_events,
+                        ethindex_db.get_user_events,
                         type,
                         user_address=user_address,
                         from_block=from_block,
@@ -627,7 +627,7 @@ class TrustlinesRelay:
             else:
                 queries.append(
                     functools.partial(
-                        ethindex_db.get_all_unw_eth_events,
+                        ethindex_db.get_all_contract_events,
                         user_address=user_address,
                         from_block=from_block,
                     )
@@ -644,8 +644,8 @@ class TrustlinesRelay:
             if type is not None and type in ethindex_db.standard_event_types:
                 queries.append(
                     functools.partial(
-                        ethindex_db.get_exchange_events,
-                        type,
+                        ethindex_db.get_user_events,
+                        event_name=type,
                         user_address=user_address,
                         from_block=from_block,
                     )
@@ -653,7 +653,7 @@ class TrustlinesRelay:
             else:
                 queries.append(
                     functools.partial(
-                        ethindex_db.get_all_exchange_events,
+                        ethindex_db.get_all_contract_events,
                         user_address=user_address,
                         from_block=from_block,
                     )
@@ -670,18 +670,16 @@ class TrustlinesRelay:
 
         if token_address in self.unw_eth_addresses:
             ethindex_db = self.get_ethindex_db_for_unw_eth(token_address)
-            func_names = ["get_unw_eth_events", "get_all_unw_eth_events"]
         else:
             ethindex_db = self.get_ethindex_db_for_token(token_address)
-            func_names = ["get_token_events", "get_all_token_events"]
 
         if type is not None:
-            events = getattr(ethindex_db, func_names[0])(
-                type, user_address, from_block=from_block
+            events = getattr(ethindex_db, "get_user_events")(
+                event_name=type, user_address=user_address, from_block=from_block
             )
         else:
-            events = getattr(ethindex_db, func_names[1])(
-                user_address, from_block=from_block
+            events = getattr(ethindex_db, "get_all_contract_events")(
+                user_address=user_address, from_block=from_block
             )
 
         return events
@@ -721,15 +719,17 @@ class TrustlinesRelay:
     ) -> List[BlockchainEvent]:
         ethindex_db = self.get_ethindex_db_for_exchange(exchange_address)
         if type is not None:
-            events = ethindex_db.get_exchange_events(
-                type,
-                user_address,
+            events = ethindex_db.get_user_events(
+                event_name=type,
+                user_address=user_address,
                 from_block=from_block,
                 timeout=self.event_query_timeout,
             )
         else:
-            events = ethindex_db.get_all_exchange_events(
-                user_address, from_block=from_block, timeout=self.event_query_timeout
+            events = ethindex_db.get_all_contract_events(
+                user_address=user_address,
+                from_block=from_block,
+                timeout=self.event_query_timeout,
             )
         return events
 

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -645,7 +645,7 @@ class TrustlinesRelay:
                 queries.append(
                     functools.partial(
                         ethindex_db.get_user_events,
-                        event_name=type,
+                        event_type=type,
                         user_address=user_address,
                         from_block=from_block,
                     )
@@ -675,7 +675,7 @@ class TrustlinesRelay:
 
         if type is not None:
             events = getattr(ethindex_db, "get_user_events")(
-                event_name=type, user_address=user_address, from_block=from_block
+                event_type=type, user_address=user_address, from_block=from_block
             )
         else:
             events = getattr(ethindex_db, "get_all_contract_events")(
@@ -720,7 +720,7 @@ class TrustlinesRelay:
         ethindex_db = self.get_ethindex_db_for_exchange(exchange_address)
         if type is not None:
             events = ethindex_db.get_user_events(
-                event_name=type,
+                event_type=type,
                 user_address=user_address,
                 from_block=from_block,
                 timeout=self.event_query_timeout,

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -582,61 +582,10 @@ class TrustlinesRelay:
             timeout=timeout,
         )
 
-    def _get_network_event_queries(
-        self, user_address: str, type: str = None, from_block: int = 0
-    ):
-        assert is_checksum_address(user_address)
-        queries = []
-        for network_address in self.network_addresses:
-            ethindex_db = self.get_ethindex_db_for_currency_network(network_address)
-            if type is not None and type in ethindex_db.event_types:
-                queries.append(
-                    functools.partial(
-                        ethindex_db.get_network_events,
-                        type,
-                        user_address=user_address,
-                        from_block=from_block,
-                    )
-                )
-            else:
-                queries.append(
-                    functools.partial(
-                        ethindex_db.get_all_network_events,
-                        user_address=user_address,
-                        from_block=from_block,
-                    )
-                )
-        return queries
-
-    def _get_unw_eth_event_queries(
-        self, user_address: str, type: str = None, from_block: int = 0
-    ):
-        assert is_checksum_address(user_address)
-        queries = []
-        for unw_eth_address in self.unw_eth_addresses:
-            ethindex_db = self.get_ethindex_db_for_unw_eth(unw_eth_address)
-            if type is not None and type in ethindex_db.event_types:
-                queries.append(
-                    functools.partial(
-                        ethindex_db.get_user_events,
-                        type,
-                        user_address=user_address,
-                        from_block=from_block,
-                    )
-                )
-            else:
-                queries.append(
-                    functools.partial(
-                        ethindex_db.get_all_contract_events,
-                        user_address=user_address,
-                        from_block=from_block,
-                    )
-                )
-        return queries
-
     def _get_exchange_event_queries(
         self, user_address: str, type: str = None, from_block: int = 0
     ):
+        # TODO: remove this
         assert is_checksum_address(user_address)
         queries = []
         for exchange_address in self.exchange_addresses:


### PR DESCRIPTION
Based on: https://github.com/trustlines-protocol/relay/pull/495

I found it hard to make refactoring that was straight improvement. I hope I did the most that is not so opinionated.

I thought about removing `address` from EthindexDB because it is confusing as to which method will use a default address for filtering, but I did not think it was an obvious improvement since then all methods using the default address will need to have it as a non-optional parameter.

I had the choice to remove all `get_ethindex_db_for_...` functions and have specific classes for each contracts that inherit `EthindexDB` with static `standard_event_types`, `from_to_types` and `event_builders`,  as it is the main difference in between each of these functions. I thought that was not obviously better.

I think `get_all_contract_events` is dirty as it does too many different things depending on its arguments, and it could lead to mistake if used without `contract_address`, but it is challenging to fix it since it is used in many places. https://github.com/trustlines-protocol/relay/pull/497/files#diff-6caecb6c151ad021cb4ee3f86396524dL340