### PR TITLE
Add endpoint to get paid delegation fees via tx hash

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,6 @@ gas_price = 0
 [trustline_index]
 enable = true
 full_sync_interval = 300
-event_query_timeout = 20
 
 [tx_relay]
 enable = true

--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -1380,6 +1380,46 @@ curl --header "Content-Type: application/json" \
 
 ---
 
+### Effective delegation fees of transaction
+
+Get the delegation fees that were applied with given transaction.
+
+#### Request
+```
+GET /delegation-fees?transactionHash=hash
+```
+#### Data Parameters
+| Name            | Type   | Required | Description                                         |
+|-----------------|--------|----------|---------------------------------------------------- |
+| transactionHash | string | Yes      | Hash of transaction responsible for delegation fees |
+
+#### Example Request
+```bash
+curl https://relay0.testnet.trustlines.network/api/v1/delegation-fees?transactionHash=0x05c91f6506e78b1ca2413df9985ca7d37d2da5fc076c0b55c5d9eb9fdd7513a6
+```
+
+#### Response
+
+| Attribute             | Type                | JSON Type            | Description                                 |
+| --------------------- | ------------------- | -------------------- | ------------------------------------------- |
+| feeSender             | address             | string               | address of the payer of the fees            |
+| feeRecipient          | address             | string               | address of the recipient of the fee         |
+| totalFee              | BigInteger          | string               | total value of the fee in currency network  |
+| currencyNetworkOfFees | address             | string               | address of the currency network of the fee  |
+
+#### Example Response
+```json
+{
+    "feeSender": "0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce",
+    "feeRecipient": "0x7Ec3543702FA8F2C7b2bD84C034aAc36C263cA8b",
+    "totalFee": "123456",
+    "currencyNetworkOfFees": "0xC0B33D88C704455075a0724AA167a286da778DDE"
+
+}
+```
+
+---
+
 ### Status of meta transaction
 Get the status of a meta transaction for an identity.
 

--- a/src/relay/api/app.py
+++ b/src/relay/api/app.py
@@ -9,7 +9,7 @@ from webargs.flaskparser import abort, parser
 from werkzeug.exceptions import HTTPException
 from werkzeug.routing import BaseConverter, ValidationError
 
-from relay.api.resources import TrustlineEvents
+from relay.api.resources import AppliedDelegationFees, TrustlineEvents
 
 from .exchange.resources import (
     EventsExchange,
@@ -121,6 +121,7 @@ def ApiApp(trustlines, *, enabled_apis):
             "interests/<address:counterparty_address>",
         )
         add_resource(TransferInformation, "/transfers")
+        add_resource(AppliedDelegationFees, "/delegation-fees/")
         add_resource(
             User, "/networks/<address:network_address>/users/<address:user_address>"
         )

--- a/src/relay/api/exchange/resources.py
+++ b/src/relay/api/exchange/resources.py
@@ -11,7 +11,6 @@ from relay.api import fields
 from relay.api.exchange.schemas import OrderSchema
 from relay.api.resources import dump_result_with_schema
 from relay.blockchain.exchange_events import all_event_types as all_exchange_event_types
-from relay.concurrency_utils import TimeoutException
 from relay.exchange.order import Order
 from relay.exchange.orderbook import OrderInvalidException
 from relay.relay import TrustlinesRelay
@@ -19,8 +18,6 @@ from relay.relay import TrustlinesRelay
 from ..schemas import ExchangeEventSchema, UserExchangeEventSchema
 
 logger = logging.getLogger("api.resources")
-
-TIMEOUT_MESSAGE = "The server could not handle the request in time"
 
 
 def abort_if_invalid_order_hash(order_hash):
@@ -232,19 +229,10 @@ class UserEventsAllExchanges(Resource):
     def get(self, args, user_address: str):
         from_block = args["fromBlock"]
         type = args["type"]
-        try:
-            return self.trustlines.get_all_user_exchange_events(
-                user_address, type=type, from_block=from_block
-            )
-        except TimeoutException:
-            logger.warning(
-                """User exchange events from all exchanges:
-                   event_type=%s user_address=%s from_block=%s. could not get events in time""",
-                type,
-                user_address,
-                from_block,
-            )
-            abort(504, TIMEOUT_MESSAGE)
+
+        return self.trustlines.get_all_user_exchange_events(
+            user_address, type=type, from_block=from_block
+        )
 
 
 class EventsExchange(Resource):

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -29,6 +29,7 @@ from relay.blockchain.delegate import (
 )
 from relay.blockchain.events_informations import (
     EventNotFoundException,
+    FeesPaidNotFound,
     IdentifiedNotPartOfTransferException,
     TransferNotFoundException,
 )
@@ -41,6 +42,7 @@ from .schemas import (
     AccruedInterestListSchema,
     AggregatedAccountSummarySchema,
     AnyEventSchema,
+    AppliedDelegationFeeSchema,
     CurrencyNetworkEventSchema,
     CurrencyNetworkSchema,
     IdentityInfosSchema,
@@ -48,6 +50,7 @@ from .schemas import (
     MetaTransactionSchema,
     MetaTransactionStatusSchema,
     PaymentPathSchema,
+    TransactionIdentifierSchema,
     TransactionStatusSchema,
     TransferIdentifierSchema,
     TransferInformationSchema,
@@ -523,6 +526,23 @@ class TransferInformation(Resource):
                 )
         else:
             raise RuntimeError("Unhandled input parameters.")
+
+
+class AppliedDelegationFees(Resource):
+    def __init__(self, trustlines: TrustlinesRelay) -> None:
+        self.trustlines = trustlines
+
+    @use_args(TransactionIdentifierSchema())
+    @dump_result_with_schema(AppliedDelegationFeeSchema())
+    def get(self, args):
+        transaction_hash = args["transactionHash"]
+
+        try:
+            return self.trustlines.get_delegation_fees_for_tx(transaction_hash)
+        except FeesPaidNotFound as e:
+            abort(
+                400, f"No paid delegaton fees found for transaction hash: {e.tx_hash}"
+            )
 
 
 class TransactionInfos(Resource):

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -62,9 +62,6 @@ from .schemas import (
 logger = logging.getLogger("api.resources")
 
 
-TIMEOUT_MESSAGE = "The server could not handle the request in time"
-
-
 def abort_if_unknown_network(trustlines, network_address):
     if not trustlines.is_currency_network(network_address):
         abort(404, "Unknown network: {}".format(network_address))
@@ -396,10 +393,7 @@ class UserEvents(Resource):
         from_block = args["fromBlock"]
 
         return self.trustlines.get_user_events(
-            user_address,
-            type=type,
-            from_block=from_block,
-            timeout=self.trustlines.event_query_timeout,
+            user_address, type=type, from_block=from_block,
         )
 
 

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -81,10 +81,10 @@ class MetaTransactionFeeSchema(Schema):
 
 class AppliedDelegationFeeSchema(Schema):
 
-    sender = Address(required=True)
-    receiver = Address(required=True)
-    value = BigInteger(required=True)
-    currencyNetwork = Address(required=True, attribute="currency_network")
+    feeSender = Address(required=True, attribute="sender")
+    feeRecipient = Address(required=True, attribute="receiver")
+    totalFee = BigInteger(required=True, attribute="value")
+    currencyNetworkOfFees = Address(required=True, attribute="currency_network")
 
 
 class MetaTransactionStatusSchema(Schema):

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -79,6 +79,14 @@ class MetaTransactionFeeSchema(Schema):
     currencyNetworkOfFees = Address(required=True, attribute="currency_network_of_fees")
 
 
+class AppliedDelegationFeeSchema(Schema):
+
+    sender = Address(required=True)
+    receiver = Address(required=True)
+    value = BigInteger(required=True)
+    currencyNetwork = Address(required=True, attribute="currency_network")
+
+
 class MetaTransactionStatusSchema(Schema):
 
     status = MetaTransactionStatusField(required=True)
@@ -273,12 +281,6 @@ class AccruedInterestListSchema(Schema):
     counterparty = Address()
 
 
-class PaidFeesSchema(Schema):
-    sender = Address()
-    receiver = Address()
-    value = BigInteger()
-
-
 class TransferInformationSchema(Schema):
 
     currencyNetwork = Address(required=True, attribute="currency_network")
@@ -317,3 +319,8 @@ class TransferIdentifierSchema(Schema):
     transactionHash = Hash(required=False, missing=None)
     blockHash = Hash(required=False, missing=None)
     logIndex = fields.Int(required=False, missing=None, validate=Range(min=0))
+
+
+class TransactionIdentifierSchema(Schema):
+
+    transactionHash = Hash(required=True)

--- a/src/relay/blockchain/currency_network_events.py
+++ b/src/relay/blockchain/currency_network_events.py
@@ -8,6 +8,7 @@ TrustlineUpdateEventType = "TrustlineUpdate"
 BalanceUpdateEventType = "BalanceUpdate"
 TransferEventType = "Transfer"
 NetworkFreezeEventType = "NetworkFreeze"
+DebtUpdateEventType = "DebtUpdate"
 
 
 class CurrencyNetworkEvent(TLNetworkEvent):
@@ -74,6 +75,12 @@ class TrustlineRequestCancelEvent(CurrencyNetworkEvent):
     pass
 
 
+class DebtUpdateEvent(CurrencyNetworkEvent):
+    @property
+    def new_debt(self):
+        return self._web3_event.get("args").get("_newDebt")
+
+
 class NetworkFreezeEvent(BlockchainEvent):
     def __init__(self, web3_event, current_blocknumber: int, timestamp: int):
         super().__init__(web3_event, current_blocknumber, timestamp)
@@ -86,6 +93,7 @@ event_builders = {
     TrustlineRequestEventType: TrustlineRequestEvent,
     TrustlineRequestCancelEventType: TrustlineRequestCancelEvent,
     BalanceUpdateEventType: BalanceUpdateEvent,
+    DebtUpdateEventType: DebtUpdateEvent,
     NetworkFreezeEventType: NetworkFreezeEvent,
 }
 
@@ -96,6 +104,7 @@ from_to_types = {
     TrustlineRequestCancelEventType: ["_initiator", "_counterparty"],
     TrustlineUpdateEventType: ["_creditor", "_debtor"],
     BalanceUpdateEventType: ["_from", "_to"],
+    DebtUpdateEventType: ["_debtor", "_creditor"],
 }
 
 standard_event_types = [
@@ -103,6 +112,7 @@ standard_event_types = [
     TrustlineRequestEventType,
     TrustlineRequestCancelEventType,
     TrustlineUpdateEventType,
+    DebtUpdateEventType,
 ]
 
 trustline_event_types = [

--- a/src/relay/config/schema.py
+++ b/src/relay/config/schema.py
@@ -57,7 +57,6 @@ class FaucetSchema(Schema):
 class TrustlineIndexSchema(Schema):
     enable = fields.Boolean(missing=True)
     full_sync_interval = fields.Integer(missing=300)
-    event_query_timeout = fields.Integer(missing=20)
 
 
 class GasPriceMethodField(fields.Field):

--- a/src/relay/ethindex_db.py
+++ b/src/relay/ethindex_db.py
@@ -163,16 +163,12 @@ class EthindexDB:
         event_type: str,
         user_address: str = None,
         from_block: int = 0,
-        timeout: float = None,
         contract_address: str = None,
     ) -> List[BlockchainEvent]:
         contract_address = self._get_addr(contract_address)
         if user_address is None:
             return self.get_events(
-                event_type,
-                from_block=from_block,
-                timeout=timeout,
-                contract_address=contract_address,
+                event_type, from_block=from_block, contract_address=contract_address,
             )
 
         where_block = """WHERE blockNumber>=%s
@@ -193,11 +189,10 @@ class EthindexDB:
         events = self._run_query_where_block(where_block, query_params)
 
         logger.debug(
-            "get_user_events(%s, %s, %s, %s, %s) -> %s rows",
+            "get_user_events(%s, %s, %s, %s) -> %s rows",
             event_type,
             user_address,
             from_block,
-            timeout,
             contract_address,
             len(events),
         )
@@ -214,7 +209,6 @@ class EthindexDB:
         event_types: Iterable[str] = None,
         user_address: str = None,
         from_block: int = 0,
-        timeout: float = None,
         contract_address: str = None,
     ) -> List[BlockchainEvent]:
         # This function only works properly for many contracts if self.contract_types is properly set
@@ -251,11 +245,10 @@ class EthindexDB:
         events = self._run_query_where_block(where_block, args)
 
         logger.debug(
-            "get_all_contract_events(%s, %s, %s, %s, %s) -> %s rows",
+            "get_all_contract_events(%s, %s, %s, %s) -> %s rows",
             event_types,
             user_address,
             from_block,
-            timeout,
             contract_address,
             len(events),
         )
@@ -268,11 +261,7 @@ class EthindexDB:
         return events
 
     def get_events(
-        self,
-        event_type,
-        from_block=0,
-        timeout: float = None,
-        contract_address: str = None,
+        self, event_type, from_block=0, contract_address: str = None,
     ) -> List[BlockchainEvent]:
         contract_address = self._get_addr(contract_address)
 
@@ -285,10 +274,9 @@ class EthindexDB:
         events = self._run_query_where_block(where_block, query_params)
 
         logger.debug(
-            "get_events(%s, %s, %s, %s) -> %s rows",
+            "get_events(%s, %s, %s) -> %s rows",
             event_type,
             from_block,
-            timeout,
             contract_address,
             len(events),
         )
@@ -298,7 +286,6 @@ class EthindexDB:
     def get_all_events(
         self,
         from_block: int = 0,
-        timeout: float = None,
         contract_address: str = None,
         standard_event_types=None,
     ) -> List[BlockchainEvent]:
@@ -315,7 +302,6 @@ class EthindexDB:
         logger.debug(
             "get_all_events(%s, %s, %s) -> %s rows",
             from_block,
-            timeout,
             contract_address,
             len(events),
         )
@@ -374,22 +360,15 @@ class EthindexDB:
 
 class CurrencyNetworkEthindexDB(EthindexDB):
     def get_network_events(
-        self,
-        event_type: str,
-        user_address: str = None,
-        from_block: int = 0,
-        timeout: float = None,
+        self, event_type: str, user_address: str = None, from_block: int = 0,
     ) -> List[BlockchainEvent]:
-        return self.get_user_events(event_type, user_address, from_block, timeout)
+        return self.get_user_events(event_type, user_address, from_block)
 
     def get_all_network_events(
-        self, user_address: str = None, from_block: int = 0, timeout: float = None
+        self, user_address: str = None, from_block: int = 0
     ) -> List[BlockchainEvent]:
         return self.get_all_contract_events(
-            currency_network_events.standard_event_types,
-            user_address,
-            from_block,
-            timeout,
+            currency_network_events.standard_event_types, user_address, from_block,
         )
 
     def get_trustline_events(
@@ -399,7 +378,6 @@ class CurrencyNetworkEthindexDB(EthindexDB):
         counterparty_address: str,
         event_types: Iterable[str] = None,
         from_block: int = 0,
-        timeout: float = None,
     ):
         event_types = self._get_standard_event_types(event_types)
 
@@ -425,13 +403,12 @@ class CurrencyNetworkEthindexDB(EthindexDB):
         events = self._run_query_where_block(where_block, args)
 
         logger.debug(
-            "get_trustline_events(%s, %s, %s, %s, %s, %s) -> %s rows",
+            "get_trustline_events(%s, %s, %s, %s, %s) -> %s rows",
             contract_address,
             user_address,
             counterparty_address,
             event_types,
             from_block,
-            timeout,
             len(events),
         )
 

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -493,14 +493,11 @@ class TrustlinesRelay:
         ethindex_db = self.get_ethindex_db_for_currency_network(network_address)
         if type is not None:
             events = ethindex_db.get_network_events(
-                type,
-                user_address,
-                from_block=from_block,
-                timeout=self.event_query_timeout,
+                type, user_address, from_block=from_block,
             )
         else:
             events = ethindex_db.get_all_network_events(
-                user_address, from_block=from_block, timeout=self.event_query_timeout
+                user_address, from_block=from_block
             )
         return events
 
@@ -539,21 +536,13 @@ class TrustlinesRelay:
     ) -> List[BlockchainEvent]:
         ethindex_db = self.get_ethindex_db_for_currency_network(network_address)
         if type is not None:
-            events = ethindex_db.get_events(
-                type, from_block=from_block, timeout=self.event_query_timeout
-            )
+            events = ethindex_db.get_events(type, from_block=from_block)
         else:
-            events = ethindex_db.get_all_events(
-                from_block=from_block, timeout=self.event_query_timeout
-            )
+            events = ethindex_db.get_all_events(from_block=from_block)
         return events
 
     def get_user_events(
-        self,
-        user_address: str,
-        type: str = None,
-        from_block: int = 0,
-        timeout: float = None,
+        self, user_address: str, type: str = None, from_block: int = 0,
     ) -> List[BlockchainEvent]:
         assert is_checksum_address(user_address)
         event_types: Optional[List[str]]
@@ -580,10 +569,7 @@ class TrustlinesRelay:
             contract_types=contract_types,
         )
         return ethindex.get_all_contract_events(
-            event_types,
-            user_address=user_address,
-            from_block=from_block,
-            timeout=timeout,
+            event_types, user_address=user_address, from_block=from_block,
         )
 
     def _get_exchange_event_queries(
@@ -673,31 +659,22 @@ class TrustlinesRelay:
         ethindex_db = self.get_ethindex_db_for_exchange(exchange_address)
         if type is not None:
             events = ethindex_db.get_user_events(
-                event_type=type,
-                user_address=user_address,
-                from_block=from_block,
-                timeout=self.event_query_timeout,
+                event_type=type, user_address=user_address, from_block=from_block,
             )
         else:
             events = ethindex_db.get_all_contract_events(
-                user_address=user_address,
-                from_block=from_block,
-                timeout=self.event_query_timeout,
+                user_address=user_address, from_block=from_block,
             )
         return events
 
     def get_all_user_exchange_events(
-        self,
-        user_address: str,
-        type: str = None,
-        from_block: int = 0,
-        timeout: float = None,
+        self, user_address: str, type: str = None, from_block: int = 0,
     ) -> List[BlockchainEvent]:
         assert is_checksum_address(user_address)
         exchange_event_queries = self._get_exchange_event_queries(
             user_address, type, from_block
         )
-        results = concurrency_utils.joinall(exchange_event_queries, timeout=timeout)
+        results = concurrency_utils.joinall(exchange_event_queries)
         return sorted_events(list(itertools.chain.from_iterable(results)))
 
     def _load_gas_price_settings(self, gas_price_settings: Dict):

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -274,6 +274,10 @@ class TrustlinesRelay:
         fetcher = EventsInformationFetcher(self.get_ethindex_db_for_currency_network())
         return fetcher.get_transfer_details_for_id(block_hash, log_index)
 
+    def get_delegation_fees_for_tx(self, tx_hash):
+        fetcher = EventsInformationFetcher(self.get_ethindex_db_for_currency_network())
+        return fetcher.get_delegation_fees_for_tx(tx_hash)
+
     def deploy_identity(self, factory_address, implementation_address, signature):
         return self.delegate.deploy_identity(
             factory_address, implementation_address, signature


### PR DESCRIPTION
Closes: https://github.com/trustlines-protocol/relay/issues/488

I attempted to solve the problem while making only one query to the database and not receiving too much information. This has the drawback that if there is more than one `DebtUpdate` event in the identifies transaction it does not work (we could probably make it work with better postgresql knowledge). But I believe the reason why you would have more than one such event is if the delegate is evil, and he can attack you in other way if he is evil anyway.

Also includes the removal of the remaining `timeout` in event queries and the removal of `event_query_timeout` from the config since it is not used anymore.