### PR TITLE
No longer listen on new addresses for networks / exchanges ...

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Change Log
   this endpoint returns a list of all delegations fees paid within the transaction with given hash
 - Add :code:`extraData` to response of endpoint :code:`GET /transfers?options...`
   which returns a list of information for identifies transfer
+- No longer watch address file for new currency networks, exchange, unwEth, identity proxy factory addresses
+- Deprecate config `relay.update_indexed_networks_interval`: it is no longer used and should be removed
 
 `0.15.0`_ (2020-04-21)
 -------------------------------

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,5 @@
 [relay]
 addresses_filepath = "addresses.json"
-update_indexed_networks_interval = 120
 
 [relay.gas_price_computation]
 method = "rpc"

--- a/src/relay/config/schema.py
+++ b/src/relay/config/schema.py
@@ -191,7 +191,6 @@ class ChainNodeRPCSchema(Schema):
 
 
 class RelaySchema(Schema):
-    update_indexed_networks_interval = fields.Integer(missing=120)
     gas_price_computation = fields.Nested(GasPriceComputationSchema())
     addresses_filepath = fields.String(missing="addresses.json")
 


### PR DESCRIPTION
Deprecate the relay config for the update indexed networks interval
that is relay.updateNetworksInterval and
relay.update_indexed_networks_interval

closes https://github.com/trustlines-protocol/relay/issues/75