### PR TITLE
Catch firebase error for when client token is not found

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Change Log
 `unreleased`_
 -------------------------------
 
+`0.18.0`_ (2020-09-14)
+-------------------------------
+- Fixed: error handling for firebase when client token is not found
+
 `0.17.1`_ (2020-09-08)
 -------------------------------
 - Added: `TrustlineRequestCancel` push notification support
@@ -237,4 +241,5 @@ Change Log
 .. _0.16.0: https://github.com/trustlines-protocol/relay/compare/0.15.0...0.16.0
 .. _0.17.0: https://github.com/trustlines-protocol/relay/compare/0.16.0...0.17.0
 .. _0.17.1: https://github.com/trustlines-protocol/relay/compare/0.17.0...0.17.1
-.. _unreleased: https://github.com/trustlines-protocol/relay/compare/0.17.1...master
+.. _0.18.0: https://github.com/trustlines-protocol/relay/compare/0.17.1...0.18.0
+.. _unreleased: https://github.com/trustlines-protocol/relay/compare/0.18.0...master

--- a/src/relay/pushservice/pushservice.py
+++ b/src/relay/pushservice/pushservice.py
@@ -120,7 +120,15 @@ class FirebaseRawPushService:
             if e.code in INVALID_CLIENT_TOKEN_ERRORS:
                 logger.debug(f"Invalid client token {client_token}: {e.code}")
                 return False
+            elif isinstance(e, firebase_exceptions.NotFoundError):
+                logger.debug(
+                    f"client token {client_token} not found on firebase: {e.code}"
+                )
+                return False
             else:
+                logger.debug(
+                    f"Error while checking client token {client_token}: {e.code}"
+                )
                 raise
         return True
 


### PR DESCRIPTION
See https://firebase.google.com/docs/reference/admin/python/firebase_admin.exceptions for NotFoundError

Also check the issue https://github.com/firebase/firebase-admin-python/issues/180