### PR TITLE
Enhance endpoint for user events to add filtering by contract type

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -57,6 +57,8 @@ https://relay0.testnet.trustlines.network/api/v1
 
 ---
 
+## Network context
+
 ### Currency networks list
 Returns all registered currency networks with high-level information.
 #### Request
@@ -1004,23 +1006,30 @@ The `paymentPath` is an object with the following attributes:
 
 ---
 
-### Events of user in all currency networks
-Returns a list of event logs of an user in all currency networks. That means all events where the given user address is either `from` or `to`.
+## User context
+
+### All events of users for currency networks / exchanges / tokens / unweth.
+Returns a list of all event logs of a user. That means all events where the given user address is either `from` or `to`.
+You can filter what type of events you want with `contractType` to select the contract
+and `type` to select the name of the events within the contract.
 #### Request
 ```
-GET /users/:user/events?type=:type&fromBlock=:fromBlock
+GET /users/:user/events?type=:type&fromBlock=:fromBlock&contractType:=contractType
 ```
 #### Example Request
 ```
-curl https://relay0.testnet.trustlines.network/api/v1/users/0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce/events?type=TrustlineUpdate&fromBlock=123456
+curl https://relay0.testnet.trustlines.network/api/v1/users/0xcbF1153F6e5AC01D363d432e24112e8aA56c55ce/events?type=TrustlineUpdate&fromBlock=123456&contractType=CurrencyNetwork
 ```
 #### URL Parameters
 |Name|Type|Required|Description|
 |-|-|-|-|
 |user|string|YES|Address of user|
 |type|string|NO|Either `TrustlineUpdate`, `TrustlineUpdateRequest`, `TrustlineUpdateCancel` or `Transfer`|
+|contractType|string|NO|Either `CurrencyNetwork`, `Exchange`, `UnwETH` or `Token`|
 |fromBlock|int|NO|Start of block range|
 #### Response
+For events from currency networks, they will have the following attributes:
+
 | Attribute      | Type   | Description                                                                               |
 |----------------|--------|-------------------------------------------------------------------------------------------|
 | networkAddress | string | Address of currency network                                                               |
@@ -1244,6 +1253,8 @@ curl https://relay0.testnet.trustlines.network/api/v1/users/0xE56d3f8096c765f29A
 ```
 
 ---
+
+## Other
 
 ### Latest block number
 Returns the latest block number.

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -27,6 +27,7 @@ from relay.blockchain.delegate import (
     InvalidTimeLimit,
     UnknownIdentityFactoryException,
 )
+from relay.blockchain.exchange_events import all_event_types as all_exchange_event_types
 from relay.blockchain.unw_eth_events import all_event_types as all_unw_eth_event_types
 from relay.ethindex_db.events_informations import (
     EventNotFoundException,
@@ -34,7 +35,7 @@ from relay.ethindex_db.events_informations import (
     TransferNotFoundException,
 )
 from relay.network_graph.payment_path import FeePayer, PaymentPath
-from relay.relay import TrustlinesRelay
+from relay.relay import TrustlinesRelay, all_event_contract_types
 from relay.utils import get_version, sha3
 
 from .schemas import (
@@ -379,9 +380,16 @@ class UserEvents(Resource):
         "type": fields.Str(
             required=False,
             validate=validate.OneOf(
-                all_currency_network_event_types + all_unw_eth_event_types
+                all_currency_network_event_types
+                + all_unw_eth_event_types
+                + all_exchange_event_types
             ),
             missing=None,
+        ),
+        "contractType": fields.Str(
+            required=False,
+            missing=None,
+            validate=validate.OneOf(all_event_contract_types),
         ),
     }
 
@@ -390,9 +398,13 @@ class UserEvents(Resource):
     def get(self, args, user_address: str):
         type = args["type"]
         from_block = args["fromBlock"]
+        contract_type = args["contractType"]
 
         return self.trustlines.get_user_events(
-            user_address, type=type, from_block=from_block,
+            user_address,
+            event_type=type,
+            from_block=from_block,
+            contract_type=contract_type,
         )
 
 


### PR DESCRIPTION
It was documented to provide events for currency networks, but was
actually returning events for any contracts (exchange, tokens ...)
Closes https://github.com/trustlines-protocol/relay/issues/502