### PR TITLE
Update web3 to 5.7.0 to be compatible with new contract deploy tools

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ certifi==2019.11.28       # via -c requirements.txt, requests
 cfgv==3.1.0               # via pre-commit
 chardet==3.0.4            # via -c requirements.txt, requests
 click==7.1.1              # via -c requirements.txt, black, contract-deploy-tools, pip-tools
-contract-deploy-tools==0.7.2  # via -c requirements.txt, -r dev-requirements.in
+contract-deploy-tools==0.7.3  # via -c requirements.txt, -r dev-requirements.in
 coverage==5.0.4           # via pytest-cov
 cytoolz==0.10.1           # via -c requirements.txt, eth-keyfile, eth-utils
 distlib==0.3.1            # via virtualenv
@@ -78,13 +78,13 @@ toml==0.10.0              # via -c requirements.txt, black, pre-commit
 toolz==0.10.0             # via -c requirements.txt, cytoolz
 trie==1.4.0               # via -c requirements.txt, py-evm
 typed-ast==1.4.1          # via black, mypy
-typing-extensions==3.7.4.1  # via mypy
+typing-extensions==3.7.4.3  # via -c requirements.txt, mypy, web3
 urllib3==1.25.8           # via -c requirements.txt, requests
 varint==1.0.2             # via -c requirements.txt, multiaddr
 virtualenv==20.0.31       # via pre-commit
 wcwidth==0.1.9            # via pytest
-web3==5.1.0               # via -c requirements.txt, contract-deploy-tools
-websockets==7.0           # via -c requirements.txt, web3
+web3==5.7.0               # via -c requirements.txt, contract-deploy-tools
+websockets==8.1           # via -c requirements.txt, web3
 wheel==0.34.2             # via -r dev-requirements.in
 zipp==3.1.0               # via -c requirements.txt, importlib-metadata, importlib-resources
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ cachetools==4.0.0         # via google-auth, trustlines-relay (setup.py)
 certifi==2019.11.28       # via requests, sentry-sdk
 chardet==3.0.4            # via requests
 click==7.1.1              # via contract-deploy-tools, flask, trustlines-contracts-deploy, trustlines-relay (setup.py)
-contract-deploy-tools==0.7.2  # via trustlines-contracts-deploy
+contract-deploy-tools==0.7.3  # via trustlines-contracts-deploy
 cytoolz==0.10.1           # via eth-keyfile, eth-utils
 decorator==4.4.2          # via networkx
 eth-abi==2.1.1            # via eth-account, eth-tester, web3
@@ -94,12 +94,13 @@ toolz==0.10.0             # via cytoolz
 trie==1.4.0               # via py-evm
 trustlines-contracts-bin==1.1.5  # via trustlines-contracts-deploy, trustlines-relay (setup.py)
 trustlines-contracts-deploy==1.1.6  # via trustlines-relay (setup.py)
+typing-extensions==3.7.4.3  # via web3
 uritemplate==3.0.1        # via google-api-python-client
 urllib3==1.25.8           # via requests, sentry-sdk
 varint==1.0.2             # via multiaddr
-web3==5.1.0               # via contract-deploy-tools, trustlines-contracts-deploy, trustlines-relay (setup.py)
+web3==5.7.0               # via contract-deploy-tools, trustlines-contracts-deploy, trustlines-relay (setup.py)
 webargs==5.5.3            # via trustlines-relay (setup.py)
-websockets==7.0           # via web3
+websockets==8.1           # via web3
 werkzeug==0.16.1          # via -r constraints.in, flask
 wrapt==1.12.1             # via trustlines-relay (setup.py)
 zipp==3.1.0               # via importlib-metadata

--- a/src/relay/web3provider.py
+++ b/src/relay/web3provider.py
@@ -2,6 +2,7 @@ import logging
 from enum import Enum
 from typing import MutableMapping
 
+from eth_typing import URI
 from web3 import HTTPProvider, IPCProvider, WebsocketProvider
 from web3.providers.auto import load_provider_from_uri
 
@@ -30,7 +31,7 @@ def create_provider_from_config(rpc_config: MutableMapping):
             rpc_config["port"],
         )
         logger.info("Using HTTP provider with URL {}".format(url))
-        return HTTPProvider(url)
+        return HTTPProvider(URI(url))
     elif provider_type is ProviderType.WEBSOCKET:
         url = "{}://{}:{}".format(
             "wss" if rpc_config["use_ssl"] else "ws",
@@ -38,7 +39,7 @@ def create_provider_from_config(rpc_config: MutableMapping):
             rpc_config["port"],
         )
         logger.info("Using websocket provider with URL {}".format(url))
-        return WebsocketProvider(url)
+        return WebsocketProvider(URI(url))
     elif provider_type is ProviderType.IPC:
         file_path = rpc_config["file_path"]
         logger.info("Using IPC provider with file path {}".format(file_path))


### PR DESCRIPTION
Have to upgrade web3 to make it work with new version of contract deploy tools.
With upgrading, the signature of `get_event_data` changed, even though it is a minor upgrade. After looking into it, I see that `get_event_data` is not part of the public api of web3, it is a `_utils` function and should not be used. I use a work around to replace it.

If you need me to explain it, we can jump on a call.