### PR TITLE
Feature/delegate debt

### DIFF
--- a/docs/RelayAPI.md
+++ b/docs/RelayAPI.md
@@ -43,6 +43,7 @@ https://relay0.testnet.trustlines.network/api/v1
 - [Transaction infos for user](#transaction-infos-for-user)
 - [Balance of user](#balance-of-user)
 - [All trustlines](#all-trustlines-of-user-in-all-currency-networks)
+- [All debts of user](#all-debts-of-user)
 ### Other
 - [Latest block number](#latest-block-number)
 - [Relay transaction](#relay-transaction)
@@ -1310,6 +1311,49 @@ curl https://relay0.testnet.trustlines.network/api/v1/users/0xE56d3f8096c765f29A
     }
 ]
 
+```
+
+---
+
+### All debts of user
+Returns a list of all the debts in all currency networks for the user.
+#### Request
+```
+GET /users/:userAddress/debts
+```
+#### Example Request
+```
+curl https://relay0.testnet.trustlines.network/api/v1/users/0x00a329c0648769A73afAc7F9381E08FB43dBEA72/debts
+```
+#### URL Parameters
+| Name        | Type   | Required | Description     |
+| ----------- | ------ | -------- | --------------- |
+| userAddress | string | YES      | Address of user |
+#### Response
+The response is a list of objects with the following fields:
+| Attribute       | Type    | JSON Type | Description                                                |
+| --------------- | ------- | --------- | ---------------------------------------------------------- |
+| currencyNetwork | address | string    | address of the currency network of all the following debts |
+| debts           | object  | object    | list of debts involving the user in the currency network   |
+
+Debts is a list of objects with the following fields:
+| Attribute       | Type    | JSON Type | Description                                                                       |
+| --------------- | ------- | --------- | --------------------------------------------------------------------------------- |
+| debtor          | address | string    | address of the debtor that owes money to the user / towards which user owes money |
+| value           | object  | object    | value of the debt, positive if user is owed money, negative if it owes money      |
+
+#### Example Response
+```json
+[
+  {
+    "currencyNetwork": "0xee35211C4D9126D520bBfeaf3cFee5FE7B86F221",
+    "debts": [
+      {"value": "1572", "debtor": "0xBeEac99C8439044B282E796f7C821d543AFb7C00"},
+      {"value": "1342", "debtor": "0xF5FFaFb5bbFE348097327f2Eba64Fc127f6a35E2"},
+      {"value": "633", "debtor": "0xFFa82F6639247a76365514c2F53DB8388c349d8D"}
+    ]
+  }
+]
 ```
 
 ---

--- a/src/relay/api/app.py
+++ b/src/relay/api/app.py
@@ -9,7 +9,11 @@ from webargs.flaskparser import abort, parser
 from werkzeug.exceptions import HTTPException
 from werkzeug.routing import BaseConverter, ValidationError
 
-from relay.api.resources import TrustlineEvents, UserEarnedMediationFeesList
+from relay.api.resources import (
+    TrustlineEvents,
+    UserDebtsLists,
+    UserEarnedMediationFeesList,
+)
 
 from .exchange.resources import (
     EventsExchange,
@@ -156,6 +160,7 @@ def ApiApp(trustlines, *, enabled_apis):
         add_resource(TransactionInfos, "/users/<address:user_address>/txinfos")
         add_resource(Balance, "/users/<address:user_address>/balance")
         add_resource(UserTrustlines, "/users/<address:user_address>/trustlines")
+        add_resource(UserDebtsLists, "/users/<address:user_address>/debts")
 
         api_bp.add_url_rule(
             "/networks/<address:network_address>/image",

--- a/src/relay/api/resources.py
+++ b/src/relay/api/resources.py
@@ -45,6 +45,7 @@ from .schemas import (
     AppliedDelegationFeeSchema,
     CurrencyNetworkEventSchema,
     CurrencyNetworkSchema,
+    DebtsListInCurrencyNetwork,
     IdentityInfosSchema,
     MediationFeesListSchema,
     MetaTransactionFeeSchema,
@@ -517,6 +518,35 @@ class UserEarnedMediationFeesList(Resource):
             "user": user_address,
             "network": network_address,
         }
+
+
+class UserDebtsLists(Resource):
+    def __init__(self, trustlines: TrustlinesRelay) -> None:
+        self.trustlines = trustlines
+
+    @dump_result_with_schema(DebtsListInCurrencyNetwork(many=True))
+    def get(self, user_address):
+        debts_in_all_currency_networks = self.trustlines.get_debt_list_of_user(
+            user_address
+        )
+
+        return [
+            {
+                "currency_network": currency_network,
+                "debts": [
+                    {
+                        "debtor": debtor,
+                        "value": debts_in_all_currency_networks[currency_network][
+                            debtor
+                        ],
+                    }
+                    for debtor in debts_in_all_currency_networks[
+                        currency_network
+                    ].keys()
+                ],
+            }
+            for currency_network in debts_in_all_currency_networks.keys()
+        ]
 
 
 class TransferInformation(Resource):

--- a/src/relay/api/schemas.py
+++ b/src/relay/api/schemas.py
@@ -314,6 +314,18 @@ class MediationFeesListSchema(Schema):
     network = Address()
 
 
+class Debts(Schema):
+
+    debtor = Address(required=True)
+    value = BigInteger(required=True)
+
+
+class DebtsListInCurrencyNetwork(Schema):
+
+    currencyNetwork = Address(required=True, attribute="currency_network")
+    debts = fields.Nested(Debts, many=True)
+
+
 class TransferInformationSchema(Schema):
 
     currencyNetwork = Address(required=True, attribute="currency_network")

--- a/src/relay/blockchain/currency_network_events.py
+++ b/src/relay/blockchain/currency_network_events.py
@@ -7,6 +7,7 @@ TrustlineRequestCancelEventType = "TrustlineUpdateCancel"
 TrustlineUpdateEventType = "TrustlineUpdate"
 BalanceUpdateEventType = "BalanceUpdate"
 TransferEventType = "Transfer"
+DebtUpdateEventType = "DebtUpdate"
 NetworkFreezeEventType = "NetworkFreeze"
 
 
@@ -44,6 +45,12 @@ class TransferEvent(ValueEvent):
 
 class BalanceUpdateEvent(ValueEvent):
     pass
+
+
+class DebtUpdateEvent(CurrencyNetworkEvent):
+    @property
+    def debt(self):
+        return self._web3_event.get("args").get("_newDebt")
 
 
 class TrustlineEvent(CurrencyNetworkEvent):
@@ -93,6 +100,7 @@ event_builders = {
     TrustlineRequestCancelEventType: TrustlineRequestCancelEvent,
     BalanceUpdateEventType: BalanceUpdateEvent,
     NetworkFreezeEventType: NetworkFreezeEvent,
+    DebtUpdateEventType: DebtUpdateEvent,
 }
 
 
@@ -102,6 +110,7 @@ from_to_types = {
     TrustlineRequestCancelEventType: ["_initiator", "_counterparty"],
     TrustlineUpdateEventType: ["_creditor", "_debtor"],
     BalanceUpdateEventType: ["_from", "_to"],
+    DebtUpdateEventType: ["_debtor", "_creditor"],
 }
 
 standard_event_types = [

--- a/src/relay/relay.py
+++ b/src/relay/relay.py
@@ -161,12 +161,17 @@ class TrustlinesRelay:
         """return an EthindexDB instance.
         This is being used from relay.api to query for events.
         """
+        address_to_contract_types: Dict[str, str] = {}
+        for address in self.network_addresses:
+            address_to_contract_types[address] = ContractTypes.CURRENCY_NETWORK.value
+
         return ethindex_db.CurrencyNetworkEthindexDB(
             ethindex_db.connect(""),
             address=network_address,
             standard_event_types=currency_network_events.standard_event_types,
-            event_builders=currency_network_events.event_builders,
+            event_builders=all_event_builders,
             from_to_types=currency_network_events.from_to_types,
+            address_to_contract_types=address_to_contract_types,
         )
 
     def get_ethindex_db_for_token(self, address: str):
@@ -295,6 +300,11 @@ class TrustlinesRelay:
         ).get_earned_mediation_fees_in_between_timestamps(
             user_address, empty_graph, start_time, end_time
         )
+
+    def get_debt_list_of_user(self, user_address):
+
+        event_selector = self.get_ethindex_db_for_currency_network()
+        return EventsInformationFetcher(event_selector).get_debts_lists(user_address)
 
     def deploy_identity(self, factory_address, implementation_address, signature):
         return self.delegate.deploy_identity(

--- a/tests/chain_integration/conftest.py
+++ b/tests/chain_integration/conftest.py
@@ -182,10 +182,10 @@ class CurrencyNetworkProxy(currency_network_proxy.CurrencyNetworkProxy):
         self.cancel_trustline_update(to, from_)
 
     def transfer(self, from_, value, max_fee, path, extra_data=b""):
-        txid = self._proxy.functions.transfer(
+        tx_id = self._proxy.functions.transfer(
             value, max_fee, path, extra_data
         ).transact({"from": from_})
-        self._web3.eth.waitForTransactionReceipt(txid)
+        self._web3.eth.waitForTransactionReceipt(tx_id)
 
     def transfer_on_path(self, value, path, max_fee=None, extra_data=b""):
         if max_fee is None:
@@ -219,6 +219,19 @@ class CurrencyNetworkProxy(currency_network_proxy.CurrencyNetworkProxy):
 
     def freeze_network(self):
         self._proxy.functions.freezeNetwork().transact()
+
+    def increase_debt(self, debtor, creditor, value):
+        tx_id = self._proxy.functions.increaseDebt(creditor, value).transact(
+            {"from": debtor}
+        )
+        self._web3.eth.waitForTransactionReceipt(tx_id)
+        return tx_id
+
+    def get_debt(self, debtor, creditor):
+        return self._proxy.functions.getDebt(debtor, creditor).call()
+
+    def assert_debt_value(self, debtor, creditor, value):
+        assert self.get_debt(debtor, creditor) == value
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
related to: https://github.com/trustlines-network/project/issues/752
based on https://github.com/trustlines-protocol/relay/pull/547

Endpoint to return list of debts of user.

There is no test for the api, since we never had tests for the api in the relay and mostly rely on the clientlib e2e test. However this user story does not (so far) require a clientlib function to call the endpoint. Thus there will be no test for the endpoint. I tested it manually.

To test it: 
- build the relay docker: `docker build -t trustlines/relay .`
- start the e2e tests backend with fees: `../end2end/run-e2e.sh -f -b`
- start some clientlib end2end tests to get some debts toward delegate `nyc mocha --timeout 30000 --require isomorphic-fetch -r ts-node/register tests/e2e/Trustline.test.ts`
- query for debt list: `curl localhost:5000/api/v1/users/0x00a329c0648769A73afAc7F9381E08FB43dBEA72/debts`

Missing to close user story is find whether there is a path from creditor to debtor.