### PR TITLE
Update backwards compatibility test with new clientlib version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,7 @@ jobs:
             docker tag $LOCAL_IMAGE $DOCKER_REPO
             cd end2end
             # Should point to latest stable clientlib e2e tests
-            TL_E2E_IMAGE=trustlines/e2e:v0.13.4-0 ./run-e2e.sh
+            TL_E2E_IMAGE=trustlines/e2e:v0.13.7 ./run-e2e.sh
 
   pre-commit-checks:
     executor: ubuntu-builder


### PR DESCRIPTION
The tests are now failing due to the limit in new contracts version of interest to 20% and the fact that the old tests use 300% interests.

See the fail here: https://github.com/trustlines-protocol/relay/pull/549