### PR TITLE
Report e2e tests code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: Install codecov
           command: |
-            pip install codecov==2.0.16
+            pip install codecov==2.1.10
       - save_cache:
           key: venv-{{ checksum "dev-requirements.txt" }}-{{ checksum "requirements.txt" }}
           paths:
@@ -251,6 +251,7 @@ jobs:
       LOCAL_IMAGE: relay
     working_directory: ~
     steps:
+      - config-path
       - setup_remote_docker
       - attach_workspace:
           at: '~'
@@ -268,6 +269,15 @@ jobs:
             docker tag $LOCAL_IMAGE $DOCKER_REPO
             cd end2end
             ./run-e2e.sh
+      - run:
+          name: copy out the end2end coverage file from remote docker to host
+          command: |
+            scp circleci@remote-docker:project/end2end/end2end-coverage/coverage.xml /home/circleci/repo/coverage.xml
+      - run:
+          name: upload end2end codecov
+          command: |
+            cd ~/repo
+            codecov --file coverage.xml
 
   run-backwards-compatibiltiy-end2end-tests:
     executor: ubuntu-builder
@@ -407,6 +417,7 @@ workflows:
           filters:
             <<: *tagged-filter
           requires:
+            - install
             - build-docker-image
 
       - run-backwards-compatibiltiy-end2end-tests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY ./dev-requirements.txt /relay/dev-requirements.txt
 RUN /opt/relay/bin/pip install --disable-pip-version-check -c dev-requirements.txt pip wheel setuptools
 COPY ./requirements.txt /relay/requirements.txt
 
-RUN /opt/relay/bin/pip install --disable-pip-version-check -r requirements.txt
+RUN /opt/relay/bin/pip install --disable-pip-version-check -r requirements.txt -r dev-requirements.txt
 
 COPY . /relay
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY ./dev-requirements.txt /relay/dev-requirements.txt
 RUN /opt/relay/bin/pip install --disable-pip-version-check -c dev-requirements.txt pip wheel setuptools
 COPY ./requirements.txt /relay/requirements.txt
 
-RUN /opt/relay/bin/pip install --disable-pip-version-check -r requirements.txt -r dev-requirements.txt
+RUN /opt/relay/bin/pip install --disable-pip-version-check -r requirements.txt
 
 COPY . /relay
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@ cfgv==3.1.0               # via pre-commit
 chardet==3.0.4            # via -c requirements.txt, requests
 click==7.1.1              # via -c requirements.txt, black, contract-deploy-tools, eth-index, eth-tester-rpc, pip-tools
 contract-deploy-tools==0.8.0  # via -c requirements.txt, -r dev-requirements.in
-coverage==5.0.4           # via pytest-cov
+coverage==5.3             # via -c requirements.txt, pytest-cov
 cytoolz==0.10.1           # via -c requirements.txt, eth-keyfile, eth-tester-rpc, eth-utils
 distlib==0.3.1            # via virtualenv
 entrypoints==0.3          # via flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ certifi==2019.11.28       # via requests, sentry-sdk
 chardet==3.0.4            # via requests
 click==7.1.1              # via contract-deploy-tools, eth-tester-rpc, flask, trustlines-contracts-deploy, trustlines-relay (setup.py)
 contract-deploy-tools==0.8.0  # via -r constraints.in, trustlines-contracts-deploy
+coverage==5.3             # via trustlines-relay (setup.py)
 cytoolz==0.10.1           # via eth-keyfile, eth-tester-rpc, eth-utils
 decorator==4.4.2          # via networkx
 eth-abi==2.1.1            # via eth-account, eth-tester, web3

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "click",
         "toml",
         "cachetools",
+        "coverage",
     ],
     python_requires=">=3.6",
     entry_points={"console_scripts": ["tl-relay=relay.boot:main"]},


### PR DESCRIPTION
Requires https://github.com/trustlines-protocol/end2end/pull/37 (right now it points to this branch in the circleci config, but once merged I'll point back to master)
You can see the new fancy coverage report there: https://codecov.io/gh/trustlines-protocol/relay/list/592316de12e346ede03f56514e23ca1f4c6bc2df/