### PR TITLE
Use ethindex to update is_frozen status on graph

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Change Log
 ==========
 `unreleased`_
 -------------------------------
+- Updated: Use ethindex to update `is_frozen` status of network graphs instead of filters
+  requires ethindex>=0.3.5
 
 `0.19.0`_ (2020-01-26)
 -------------------------------

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -9,6 +9,5 @@ flake8-string-format
 pytest
 pytest-cov
 mypy
-contract-deploy-tools>=0.8.0
 pre-commit
-eth-index
+eth-index>=0.3.5

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,45 +9,38 @@ attrs==19.3.0             # via -c requirements.txt, black, eth-index, jsonschem
 base58==2.0.0             # via -c requirements.txt, multiaddr
 bitarray==1.2.2           # via -c requirements.txt, eth-account
 black==19.10b0            # via -r dev-requirements.in
-blake2b-py==0.1.3         # via -c requirements.txt, py-evm
-cached-property==1.5.2    # via -c requirements.txt, py-evm
 certifi==2019.11.28       # via -c requirements.txt, requests
 cfgv==3.1.0               # via pre-commit
 chardet==3.0.4            # via -c requirements.txt, requests
-click==7.1.1              # via -c requirements.txt, black, contract-deploy-tools, eth-index, eth-tester-rpc, pip-tools
-contract-deploy-tools==0.9.1  # via -c requirements.txt, -r dev-requirements.in
+click==7.1.1              # via -c requirements.txt, black, eth-index, pip-tools
 coverage==5.3             # via -c requirements.txt, pytest-cov
-cytoolz==0.10.1           # via -c requirements.txt, eth-keyfile, eth-tester-rpc, eth-utils
+cytoolz==0.10.1           # via -c requirements.txt, eth-keyfile, eth-utils
 distlib==0.3.1            # via virtualenv
 entrypoints==0.3          # via flake8
-eth-abi==2.1.1            # via -c requirements.txt, eth-account, eth-tester, web3
+eth-abi==2.1.1            # via -c requirements.txt, eth-account, web3
 eth-account==0.5.4        # via -c requirements.txt, web3
-eth-bloom==1.0.3          # via -c requirements.txt, py-evm
-eth-hash[pycryptodome,pysha3]==0.2.0  # via -c requirements.txt, eth-bloom, eth-tester, eth-tester-rpc, eth-utils, trie, web3
-eth-index==0.3.4          # via -r dev-requirements.in
-eth-keyfile==0.5.1        # via -c requirements.txt, contract-deploy-tools, eth-account
-eth-keys==0.2.4           # via -c requirements.txt, eth-account, eth-keyfile, eth-tester, py-evm
+eth-hash[pycryptodome,pysha3]==0.2.0  # via -c requirements.txt, eth-utils, web3
+eth-index==0.3.5          # via -r dev-requirements.in
+eth-keyfile==0.5.1        # via -c requirements.txt, eth-account
+eth-keys==0.2.4           # via -c requirements.txt, eth-account, eth-keyfile
 eth-rlp==0.2.1            # via -c requirements.txt, eth-account
-eth-tester-rpc==0.5.0b1   # via -c requirements.txt, contract-deploy-tools
-eth-tester[py-evm]==0.5.0b3  # via -c requirements.txt, contract-deploy-tools, eth-tester-rpc
-eth-typing==2.2.1         # via -c requirements.txt, eth-abi, eth-utils, py-ecc, py-evm, web3
-eth-utils==1.9.5          # via -c requirements.txt, contract-deploy-tools, eth-abi, eth-account, eth-keyfile, eth-keys, eth-rlp, eth-tester, eth-tester-rpc, hexbytes, py-ecc, py-evm, rlp, trie, web3
+eth-typing==2.2.1         # via -c requirements.txt, eth-abi, eth-utils, web3
+eth-utils==1.9.5          # via -c requirements.txt, eth-abi, eth-account, eth-keyfile, eth-keys, eth-rlp, hexbytes, rlp, web3
 filelock==3.0.12          # via virtualenv
 flake8-string-format==0.3.0  # via -r dev-requirements.in
 flake8==3.7.9             # via -r dev-requirements.in, flake8-string-format
-hexbytes==0.2.0           # via -c requirements.txt, eth-account, eth-rlp, trie, web3
+hexbytes==0.2.0           # via -c requirements.txt, eth-account, eth-rlp, web3
 identify==1.4.12          # via pre-commit
 idna==2.9                 # via -c requirements.txt, requests
 importlib-metadata==1.7.0  # via -c requirements.txt, eth-index, jsonschema, pluggy, pre-commit, pytest, virtualenv
 importlib-resources==3.0.0  # via pre-commit, virtualenv
 ipfshttpclient==0.4.12    # via -c requirements.txt, web3
-json-rpc==1.13.0          # via -c requirements.txt, eth-tester-rpc
 jsonschema==3.2.0         # via -c requirements.txt, web3
-lru-dict==1.1.6           # via -c requirements.txt, py-evm, web3
+lru-dict==1.1.6           # via -c requirements.txt, web3
 mccabe==0.6.1             # via flake8
 more-itertools==8.2.0     # via pytest
 multiaddr==0.0.9          # via -c requirements.txt, ipfshttpclient
-mypy-extensions==0.4.3    # via -c requirements.txt, mypy, py-ecc, py-evm
+mypy-extensions==0.4.3    # via -c requirements.txt, mypy
 mypy==0.770               # via -r dev-requirements.in
 netaddr==0.7.19           # via -c requirements.txt, multiaddr
 nodeenv==1.3.5            # via pre-commit
@@ -59,13 +52,9 @@ pluggy==0.13.1            # via pytest
 pre-commit==2.2.0         # via -r dev-requirements.in
 protobuf==3.11.3          # via -c requirements.txt, web3
 psycopg2==2.8.4           # via -c requirements.txt, eth-index
-py-ecc==1.7.1             # via -c requirements.txt, py-evm
-py-evm==0.3.0a20          # via -c requirements.txt, eth-tester
-py-solc==3.2.0            # via -c requirements.txt, contract-deploy-tools
 py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via flake8
 pycryptodome==3.9.7       # via -c requirements.txt, eth-hash, eth-keyfile
-pyethash==0.1.27          # via -c requirements.txt, py-evm
 pyflakes==2.1.1           # via flake8
 pyparsing==2.4.6          # via packaging
 pyrsistent==0.15.7        # via -c requirements.txt, jsonschema
@@ -75,22 +64,18 @@ pytest==5.4.1             # via -r dev-requirements.in, pytest-cov
 pyyaml==5.3.1             # via pre-commit
 regex==2020.2.20          # via black
 requests==2.23.0          # via -c requirements.txt, ipfshttpclient, web3
-rlp==2.0.1                # via -c requirements.txt, eth-account, eth-rlp, eth-tester, py-evm, trie
-semantic-version==2.8.4   # via -c requirements.txt, eth-tester, py-solc
+rlp==2.0.1                # via -c requirements.txt, eth-account, eth-rlp
 six==1.14.0               # via -c requirements.txt, ipfshttpclient, jsonschema, multiaddr, packaging, parsimonious, pip-tools, protobuf, pyrsistent, virtualenv
-sortedcontainers==2.3.0   # via -c requirements.txt, trie
 toml==0.10.0              # via -c requirements.txt, black, pre-commit
 toolz==0.10.0             # via -c requirements.txt, cytoolz
-trie==2.0.0-alpha.5       # via -c requirements.txt, py-evm
 typed-ast==1.4.1          # via black, mypy
-typing-extensions==3.7.4.3  # via -c requirements.txt, mypy, trie, web3
+typing-extensions==3.7.4.3  # via -c requirements.txt, mypy, web3
 urllib3==1.25.8           # via -c requirements.txt, requests
 varint==1.0.2             # via -c requirements.txt, multiaddr
 virtualenv==20.0.31       # via pre-commit
 wcwidth==0.1.9            # via pytest
-web3==5.9.0               # via -c requirements.txt, contract-deploy-tools, eth-index
+web3==5.9.0               # via -c requirements.txt, eth-index
 websockets==8.1           # via -c requirements.txt, web3
-werkzeug==0.16.1          # via -c requirements.txt, eth-tester-rpc
 wheel==0.34.2             # via -r dev-requirements.in
 zipp==3.1.0               # via -c requirements.txt, importlib-metadata, importlib-resources
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,7 @@ tinyrpc==1.0.4            # via trustlines-relay (setup.py)
 toml==0.10.0              # via trustlines-relay (setup.py)
 toolz==0.10.0             # via cytoolz
 trie==2.0.0-alpha.5       # via py-evm
-trustlines-contracts-bin==1.2.0  # via trustlines-contracts-deploy, trustlines-relay (setup.py)
+trustlines-contracts-bin==1.3.0  # via trustlines-contracts-deploy, trustlines-relay (setup.py)
 trustlines-contracts-deploy==1.2.0  # via trustlines-relay (setup.py)
 typing-extensions==3.7.4.3  # via trie, web3
 uritemplate==3.0.1        # via google-api-python-client

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "gevent",
         "web3>=5.0,<6.0",
         "networkx>=2.0",
-        "trustlines-contracts-bin>=1.2.0,<1.3.0",
+        "trustlines-contracts-bin>=1.3.0,<1.4.0",
         "trustlines-contracts-deploy>=1.2.0,<1.3.0",
         "contract-deploy-tools>=0.9.1,<0.10.0",
         "sqlalchemy",

--- a/src/relay/blockchain/currency_network_proxy.py
+++ b/src/relay/blockchain/currency_network_proxy.py
@@ -5,7 +5,6 @@ from gevent import Greenlet
 
 from .currency_network_events import (
     BalanceUpdateEventType,
-    NetworkFreezeEventType,
     TransferEventType,
     TrustlineRequestCancelEventType,
     TrustlineRequestEventType,
@@ -49,7 +48,6 @@ class CurrencyNetworkProxy(Proxy):
         )
         # Fixed for now, see contracts
         self.interest_rate_decimals = 2
-        self.is_frozen = self._proxy.functions.isNetworkFrozen().call()
 
     def fetch_users(self) -> List[str]:
         return list(self._proxy.functions.getUsers().call())
@@ -143,14 +141,4 @@ class CurrencyNetworkProxy(Proxy):
 
         return self.start_listen_on(
             TransferEventType, log, start_log_filter=start_log_filter
-        )
-
-    def start_listen_on_network_freeze(
-        self, on_network_freeze, *, start_log_filter=True
-    ):
-        def log(log_entry):
-            on_network_freeze(self._build_event(log_entry))
-
-        return self.start_listen_on(
-            NetworkFreezeEventType, log, start_log_filter=start_log_filter
         )

--- a/src/relay/network_graph/graph.py
+++ b/src/relay/network_graph/graph.py
@@ -8,6 +8,8 @@ import networkx as nx
 
 from relay.ethindex_db.sync_updates import (
     BalanceUpdateFeedUpdate,
+    NetworkFreezeFeedUpdate,
+    NetworkUnfreezeFeedUpdate,
     TrustlineUpdateFeedUpdate,
 )
 from relay.network_graph.graph_constants import balance_ab, creditline_ab, creditline_ba
@@ -484,12 +486,13 @@ class CurrencyNetworkGraph(object):
         default_interest_rate=0,
         custom_interests=False,
         prevent_mediator_interests=False,
+        is_frozen=False,
     ):
-
         self.capacity_imbalance_fee_divisor = capacity_imbalance_fee_divisor
         self.default_interest_rate = default_interest_rate
         self.custom_interests = custom_interests
         self.prevent_mediator_interests = prevent_mediator_interests
+        self.is_frozen = is_frozen
         self.graph = nx.Graph()
 
     def gen_network(self, trustlines: List[Any]):
@@ -639,6 +642,10 @@ class CurrencyNetworkGraph(object):
                 feed_update.value,
                 feed_update.timestamp,
             )
+        elif type(feed_update) == NetworkFreezeFeedUpdate:
+            self.is_frozen = True
+        elif type(feed_update) == NetworkUnfreezeFeedUpdate:
+            self.is_frozen = False
         else:
             raise RuntimeError(f"Got feed update of unexpected type {feed_update}")
 

--- a/tests/chain_integration/conftest.py
+++ b/tests/chain_integration/conftest.py
@@ -209,7 +209,10 @@ class CurrencyNetworkProxy(currency_network_proxy.CurrencyNetworkProxy):
         return self._proxy.functions.balance(from_, to).call()
 
     def freeze_network(self):
-        self._proxy.functions.freezeNetwork().transact()
+        return self._proxy.functions.testFreezeNetwork().transact()
+
+    def unfreeze_network(self):
+        return self._proxy.functions.testUnfreezeNetwork().transact()
 
     def increase_debt(self, debtor, creditor, value):
         tx_id = self._proxy.functions.increaseDebt(creditor, value).transact(

--- a/tests/chain_integration/test_currency_network.py
+++ b/tests/chain_integration/test_currency_network.py
@@ -157,23 +157,3 @@ def test_listen_on_trustline_update_with_interests(currency_network, accounts):
     assert events[0].is_frozen is False
 
     greenlet.kill()
-
-
-def test_listen_on_freeze_network(currency_network, chain, expiration_time):
-    chain.time_travel(expiration_time)
-    chain.mine_block()
-
-    events = []
-
-    def f(event):
-        events.append(event)
-
-    greenlet = currency_network.start_listen_on_network_freeze(f)
-    context_switch()
-    currency_network.freeze_network()
-    gevent.sleep(1)
-
-    assert len(events) == 1
-    assert events[0].network_address == currency_network.address
-
-    greenlet.kill()


### PR DESCRIPTION
No longer uses filters to update proxy on is_frozen status of graph
Filters should not update the state of currency networks and leave
that task to ethindex.
Requires ethindex >= 0.3.5
also requires new version of contracts for testing with `NetworkUnfreeze` event