### PR TITLE
Fix relay crash due to wrong logger arguments

### DIFF
--- a/src/relay/ethindex_db/ethindex_db.py
+++ b/src/relay/ethindex_db/ethindex_db.py
@@ -398,7 +398,7 @@ class EthindexDB:
 
         events = self._run_events_query(query)
         logger.debug(
-            "get_all_events(%s, %s, %s) -> %s rows",
+            "get_all_events(%s, %s, standard_event_types) -> %s rows",
             from_block,
             contract_address,
             len(events),


### PR DESCRIPTION
--- Logging error ---
Traceback (most recent call last):
  File "/opt/relay/lib/python3.8/site-packages/flask_sockets.py", line 40, in __call__
    handler, values = adapter.match()
  File "/opt/relay/lib/python3.8/site-packages/werkzeug/routing.py", line 1799, in match
    raise NotFound()
werkzeug.exceptions.NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.8/logging/__init__.py", line 1081, in emit
    msg = self.format(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 925, in format
    return fmt.format(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 664, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.8/logging/__init__.py", line 369, in getMessage
    msg = msg % self.args
TypeError: not enough arguments for format string
Call stack:
  File "/opt/relay/lib/python3.8/site-packages/gevent/baseserver.py", line 34, in _handle_and_close_when_done
    return handle(*args_tuple)
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 1577, in handle
    handler.handle()
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 464, in handle
    result = self.handle_one_request()
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 694, in handle_one_request
    self.handle_one_response()
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 999, in handle_one_response
    self.run_application()
  File "/opt/relay/lib/python3.8/site-packages/geventwebsocket/handler.py", line 87, in run_application
    return super(WebSocketHandler, self).run_application()
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 945, in run_application
    self.result = self.application(self.environ, self.start_response)
  File "/opt/relay/lib/python3.8/site-packages/sentry_sdk/integrations/flask.py", line 89, in sentry_patched_wsgi_app
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/opt/relay/lib/python3.8/site-packages/sentry_sdk/integrations/wsgi.py", line 122, in __call__
    rv = self.app(
  File "/opt/relay/lib/python3.8/site-packages/sentry_sdk/integrations/flask.py", line 89, in <lambda>
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/opt/relay/lib/python3.8/site-packages/flask/app.py", line 2463, in __call__
    return self.wsgi_app(environ, start_response)
  File "/opt/relay/lib/python3.8/site-packages/flask_sockets.py", line 48, in __call__
    return self.wsgi_app(environ, start_response)
  File "/opt/relay/lib/python3.8/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/relay/lib/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/relay/lib/python3.8/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/relay/lib/python3.8/site-packages/flask_restful/__init__.py", line 468, in wrapper
    resp = resource(*args, **kwargs)
  File "/opt/relay/lib/python3.8/site-packages/flask/views.py", line 89, in view
    return self.dispatch_request(*args, **kwargs)
  File "/opt/relay/lib/python3.8/site-packages/flask_restful/__init__.py", line 583, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/opt/relay/lib/python3.8/site-packages/webargs/core.py", line 459, in wrapper
    return func(*new_args, **kwargs)
  File "/opt/relay/lib/python3.8/site-packages/relay/api/resources.py", line 89, in dump_result
    return schema.dump(wrapped(*args, **kwargs))
  File "/opt/relay/lib/python3.8/site-packages/relay/api/resources.py", line 434, in get
    return self.trustlines.get_network_events(
  File "/opt/relay/lib/python3.8/site-packages/relay/relay.py", line 622, in get_network_events
    events = ethindex_db.get_all_events(from_block=from_block)
  File "/opt/relay/lib/python3.8/site-packages/relay/ethindex_db/ethindex_db.py", line 400, in get_all_events
    logger.debug(
  File "/usr/lib/python3.8/logging/__init__.py", line 1430, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/opt/relay/lib/python3.8/site-packages/relay/boot.py", line 28, in _log
    super()._log(level, msg, args, exc_info, extra)
  File "/usr/lib/python3.8/logging/__init__.py", line 1585, in _log
    self.handle(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1595, in handle
    self.callHandlers(record)
  File "/opt/relay/lib/python3.8/site-packages/sentry_sdk/integrations/logging.py", line 77, in sentry_patched_callhandlers
    return old_callhandlers(self, record)
Message: 'get_all_events(%s, %s, %s) -> %s rows'
Arguments: (0, '0x35c2D7Ec13af15D6ED7a3eb1e5b911E419D9636d', 759)
--- Logging error ---
Traceback (most recent call last):
  File "/opt/relay/lib/python3.8/site-packages/flask_sockets.py", line 40, in __call__
    handler, values = adapter.match()
  File "/opt/relay/lib/python3.8/site-packages/werkzeug/routing.py", line 1799, in match
    raise NotFound()
werkzeug.exceptions.NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.8/logging/__init__.py", line 1081, in emit
    msg = self.format(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 925, in format
    return fmt.format(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 664, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.8/logging/__init__.py", line 369, in getMessage
    msg = msg % self.args
TypeError: not enough arguments for format string
Call stack:
  File "/opt/relay/lib/python3.8/site-packages/gevent/baseserver.py", line 34, in _handle_and_close_when_done
    return handle(*args_tuple)
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 1577, in handle
    handler.handle()
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 464, in handle
    result = self.handle_one_request()
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 694, in handle_one_request
    self.handle_one_response()
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 999, in handle_one_response
    self.run_application()
  File "/opt/relay/lib/python3.8/site-packages/geventwebsocket/handler.py", line 87, in run_application
    return super(WebSocketHandler, self).run_application()
  File "/opt/relay/lib/python3.8/site-packages/gevent/pywsgi.py", line 945, in run_application
    self.result = self.application(self.environ, self.start_response)
  File "/opt/relay/lib/python3.8/site-packages/sentry_sdk/integrations/flask.py", line 89, in sentry_patched_wsgi_app
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/opt/relay/lib/python3.8/site-packages/sentry_sdk/integrations/wsgi.py", line 122, in __call__
    rv = self.app(
  File "/opt/relay/lib/python3.8/site-packages/sentry_sdk/integrations/flask.py", line 89, in <lambda>
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/opt/relay/lib/python3.8/site-packages/flask/app.py", line 2463, in __call__
    return self.wsgi_app(environ, start_response)
  File "/opt/relay/lib/python3.8/site-packages/flask_sockets.py", line 48, in __call__
    return self.wsgi_app(environ, start_response)
  File "/opt/relay/lib/python3.8/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/relay/lib/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/relay/lib/python3.8/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/relay/lib/python3.8/site-packages/flask_restful/__init__.py", line 468, in wrapper
    resp = resource(*args, **kwargs)