### PR TITLE
Update tests that were failing due to removal of test network

### DIFF
--- a/tests/chain_integration/database_integration/conftest.py
+++ b/tests/chain_integration/database_integration/conftest.py
@@ -227,6 +227,7 @@ def address_file_path(
     currency_network_with_trustlines_and_interests_session,
     currency_network_with_trustlines_session,
     currency_network,
+    test_currency_network_v1,
 ):
     tmp_path_factory.mktemp("tmp_test_dir")
     path = os.path.join(tmp_path_factory.getbasetemp(), "addresses.json")
@@ -237,6 +238,7 @@ def address_file_path(
                     currency_network_with_trustlines_and_interests_session.address,
                     currency_network_with_trustlines_session.address,
                     currency_network.address,
+                    test_currency_network_v1.address,
                 ]
             },
             f,

--- a/tests/chain_integration/database_integration/test_graph_sync.py
+++ b/tests/chain_integration/database_integration/test_graph_sync.py
@@ -403,11 +403,11 @@ def test_get_event_feed_replaced_balance_update(
 
 
 def test_get_event_feed_network_freeze(
-    currency_network_with_trustlines_and_interests_session: CurrencyNetworkProxy,
+    test_currency_network_v1: CurrencyNetworkProxy,
     wait_for_ethindex_to_sync,
     generic_db_connection,
 ):
-    currency_network = currency_network_with_trustlines_and_interests_session
+    currency_network = test_currency_network_v1
     currency_network.freeze_network()
 
     wait_for_ethindex_to_sync()
@@ -419,11 +419,11 @@ def test_get_event_feed_network_freeze(
 
 
 def test_get_event_feed_network_unfreeze(
-    currency_network_with_trustlines_and_interests_session: CurrencyNetworkProxy,
+    test_currency_network_v1: CurrencyNetworkProxy,
     wait_for_ethindex_to_sync,
     generic_db_connection,
 ):
-    currency_network = currency_network_with_trustlines_and_interests_session
+    currency_network = test_currency_network_v1
     currency_network.freeze_network()
     currency_network.unfreeze_network()
 
@@ -435,13 +435,13 @@ def test_get_event_feed_network_unfreeze(
 
 
 def test_get_event_feed_reversed_network_freeze(
-    currency_network_with_trustlines_and_interests_session: CurrencyNetworkProxy,
+    test_currency_network_v1: CurrencyNetworkProxy,
     wait_for_ethindex_to_sync,
     generic_db_connection,
     chain,
     replace_blocks_with_empty_from_snapshot,
 ):
-    currency_network = currency_network_with_trustlines_and_interests_session
+    currency_network = test_currency_network_v1
 
     snapshot = chain.take_snapshot()
     currency_network.freeze_network()
@@ -457,13 +457,13 @@ def test_get_event_feed_reversed_network_freeze(
 
 
 def test_get_event_feed_reversed_network_unfreeze(
-    currency_network_with_trustlines_and_interests_session: CurrencyNetworkProxy,
+    test_currency_network_v1: CurrencyNetworkProxy,
     wait_for_ethindex_to_sync,
     generic_db_connection,
     chain,
     replace_blocks_with_empty_from_snapshot,
 ):
-    currency_network = currency_network_with_trustlines_and_interests_session
+    currency_network = test_currency_network_v1
 
     snapshot = chain.take_snapshot()
     currency_network.freeze_network()

--- a/tests/chain_integration/test_currency_network.py
+++ b/tests/chain_integration/test_currency_network.py
@@ -63,8 +63,9 @@ def test_users(currency_network_with_trustlines, accounts):
     assert currency_network_with_trustlines.fetch_users() == accounts[0:7]
 
 
-def test_is_frozen(currency_network):
+def test_is_frozen(currency_network, chain):
     assert currency_network.fetch_is_frozen_status() is False
+    currency_network.time_travel_to_expiration(chain)
     currency_network.freeze_network()
     assert currency_network.fetch_is_frozen_status() is True
 


### PR DESCRIPTION
The tests now use the v2 of the network instead of `TestCurrencyNetwork`
so they lack the function of freezing / unfreezing a network and setting
trustlines for users.

A test currency network fixture was added for the few remaining test
that need it.