### PR TITLE
Lower indexer required confirmation in tests to 50

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ executors:
   ubuntu-builder:
     docker:
       - image: trustlines/builder:master61
+    resource_class:
+      medium
     working_directory: ~/repo
 
 # define some common commands

--- a/tests/chain_integration/database_integration/conftest.py
+++ b/tests/chain_integration/database_integration/conftest.py
@@ -26,7 +26,7 @@ See tests/chain_integration/database_integration/conftest.py for actual values
 """
 
 
-INDEXER_REQUIRED_CONFIRMATION = 10_000
+INDEXER_REQUIRED_CONFIRMATION = 50
 POSTGRES_USER = "trustlines_test"
 POSTGRES_PASSWORD = "test123"
 POSTGRES_DATABASE = "trustlines_test"


### PR DESCRIPTION
This speeds up tests using the indexer a lot.
This should also make them non-flaky as the tests won't have to
wait for as long for the indexer to sync.