### PR TITLE
Drop support for websockets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Change Log
 `unreleased`_
 -------------------------------
 
+- Updated: dropped support for websocket connection to the blockchain node. It was not working due to a conflict
+  in between the concurrency library used by web3's websocket and gevent.
+
 `0.21.0`_ (2021-04-28)
 -------------------------------
 - Updated: Add `transfer` argument to schema for `TrustlineUpdateRequest` events corresponding to change

--- a/config.toml
+++ b/config.toml
@@ -16,8 +16,7 @@ enable = true
 enable = true
 
 [node_rpc]
-## Possible values for connection type are ipc, http, websocket. Default: http
-## type = websocket
+## Possible values for connection type are ipc, or http. Default: http
 port = 8545
 host = "localhost"
 use_ssl = false

--- a/src/relay/web3provider.py
+++ b/src/relay/web3provider.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import MutableMapping
 
 from eth_typing import URI
-from web3 import HTTPProvider, IPCProvider, WebsocketProvider
+from web3 import HTTPProvider, IPCProvider
 from web3.providers.auto import load_provider_from_uri
 
 logger = logging.getLogger("web3provider")
@@ -11,7 +11,6 @@ logger = logging.getLogger("web3provider")
 
 class ProviderType(Enum):
     HTTP = "http"
-    WEBSOCKET = "websocket"
     IPC = "ipc"
 
 
@@ -32,14 +31,6 @@ def create_provider_from_config(rpc_config: MutableMapping):
         )
         logger.info("Using HTTP provider with URL {}".format(url))
         return HTTPProvider(URI(url))
-    elif provider_type is ProviderType.WEBSOCKET:
-        url = "{}://{}:{}".format(
-            "wss" if rpc_config["use_ssl"] else "ws",
-            rpc_config["host"],
-            rpc_config["port"],
-        )
-        logger.info("Using websocket provider with URL {}".format(url))
-        return WebsocketProvider(URI(url))
     elif provider_type is ProviderType.IPC:
         file_path = rpc_config["file_path"]
         logger.info("Using IPC provider with file path {}".format(file_path))


### PR DESCRIPTION
It was broken due to conflict in between asyncio and gevent

closes https://github.com/trustlines-protocol/relay/issues/580